### PR TITLE
Add hosting mode switch and deployment doc

### DIFF
--- a/For Developer/DeploymentBook/README.md
+++ b/For Developer/DeploymentBook/README.md
@@ -1,0 +1,32 @@
+# DeploymentBook
+
+Bu sənəd WebAdminPanel modulunun yerləşdirilməsi üçün addımları və rejimləri izah edir.
+
+## Hosting rejimləri
+- **Standalone (.exe)** – Kestrel üzərində işləyən və Windows servis kimi işə düşə bilən rejim.
+- **WebServer (IIS/Apache/Nginx)** – Ənənəvi hostinq, Kestrel reverse proxy ilə və ya IIS in-process.
+
+### Konfiqurasiya
+`appsettings.json` faylında `Hosting:Mode` dəyərini dəyişərək rejim seçilir. 
+Əlavə olaraq `BackupBeforeSwitch` və `AutoMigrate` parametrləri mövcuddur.
+
+### Rejim dəyişdikdə
+1. Cari rejim `hosting_mode.txt` faylında saxlanılır.
+2. Yeni rejim seçildikdə əvvəlki rejimlə müqayisə olunur.
+3. `BackupBeforeSwitch` aktivdirsə, avtomatik backup `backups/` qovluğuna yaradılır.
+4. `AutoMigrate` aktivdirsə, baza miqrasiyası tətbiq olunur.
+5. Lazım gələrsə, `MigrationService` ilə bərpa əməliyyatı aparıla bilər.
+
+### IIS/Apache/Nginx yerləşdirilməsi
+1. Layihəni `dotnet publish -c Release` əmri ilə yığın.
+2. `Hosting:Mode` dəyərini `WebServer` edin.
+3. Kestrel portlarını `Kestrel:Endpoints` bölməsində tənzimləyin.
+4. Web serverdə reverse proxy qurun (IIS `web.config`, Nginx `proxy_pass`, Apache `ProxyPass`).
+5. `X-Forwarded-*` başlıqlarının ötürülməsinə əmin olun, çünki tətbiq `UseForwardedHeaders` istifadə edir.
+
+### Backup və Bərpa
+`MigrationService` vasitəsilə `CreateBackupAsync` və `RestoreBackupAsync` metodları mövcuddur. Deployment və rejim dəyişikliyi zamanı bu metodlardan istifadə etmək tövsiyə olunur.
+
+### Gələcək inkişaf
+- Avtomatik multi-instance sinxronizasiya
+- Bulud və kənar (edge) yerləşdirmə dəstəyi

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/appsettings.json
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/appsettings.json
@@ -18,6 +18,11 @@
     "MinimizeToTray": true,
     "StartMinimized": false
   },
+  "Hosting": {
+    "Mode": "Standalone",
+    "BackupBeforeSwitch": true,
+    "AutoMigrate": true
+  },
   "Kestrel": {
     "Endpoints": {
       "Http": {
@@ -42,5 +47,6 @@
     "EnablePlugins": true,
     "DefaultLanguage": "az",
     "SupportedLanguages": ["az", "en", "tr", "ru"]
-  }
+  },
+  "BackupDirectory": "backups"
 }


### PR DESCRIPTION
## Summary
- support IIS/Apache/Nginx hosting via forwarded headers and IIS integration
- allow configuring `Hosting:Mode` and automate backup + migration when switching modes
- document deployment steps in `For Developer/DeploymentBook`

## Testing
- `dotnet build WebAdminPanel/WebAdminPanel.sln -c Release` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ef4ec2b78833290a8e3d33d372f7d