### PR TITLE
Add localization resource seeding

### DIFF
--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Data/ApplicationDbContext.cs
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Data/ApplicationDbContext.cs
@@ -157,5 +157,7 @@ public class ApplicationDbContext : IdentityDbContext
             new LocalizationResource { Id = Guid.NewGuid(), Key = "Navigation.Dashboard", Value = "Панель управления", Culture = "ru", CreatedAt = DateTime.UtcNow }
         };
 
+        builder.Entity<LocalizationResource>().HasData(localizationResources);
+
     }
 }


### PR DESCRIPTION
## Summary
- ensure prepared localization resources are seeded on startup

## Testing
- `dotnet build WebAdminPanel/WebAdminPanel.sln -c Release` *(fails: .NET 9 SDK missing)*

------
https://chatgpt.com/codex/tasks/task_e_684f04a69e6483329bd958056a758e08