### PR TITLE
Fix sidebar toggle attributes

### DIFF
--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Components/Layout/NavMenu.razor
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Components/Layout/NavMenu.razor
@@ -12,7 +12,7 @@
     </div>
 </div>
 
-<button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#sidebarMenu" aria-controls="sidebarMenu" aria-expanded="false" aria-label="Toggle navigation">
+<button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#sidebarMenuContent" aria-controls="sidebarMenuContent" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
 </button>
 


### PR DESCRIPTION
## Summary
- use `#sidebarMenuContent` for the collapse target so the hamburger toggles properly

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f069d97ec8332b4cd6404751a35f8