### PR TITLE
Add external translation API

### DIFF
--- a/For Developer/LocalizationBook/README.md
+++ b/For Developer/LocalizationBook/README.md
@@ -15,5 +15,9 @@ Bu kitab WebAdminPanel modulunda tərcümə idarəçiliyi və dil paketlərinin 
 3. Eyni formatda faylı seçib yükləyərək `Import` əməliyyatı aparın.
 4. API vasitəsilə `/api/localization` endpoint-lərindən də istifadə etmək mümkündür.
 5. Tərcümə təklifi üçün `/api/translationrequests/suggest` endpoint-i POST sorğusu göndərin.
+   Sorğu bədənində `text`, `sourceCulture` və `targetCulture` sahələrini göndərin.
+6. `appsettings.json` faylında `Translation` bölməsində API açarını (`ApiKey`)
+   və provayderi (`Provider`, `Endpoint`, `Model`) təyin edin. Hazırda OpenAI və
+   DeepL dəstəklənir.
 
 Bu sənəd daim yenilənəcək.

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Models/TranslationSuggestionRequest.cs
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Models/TranslationSuggestionRequest.cs
@@ -1,0 +1,8 @@
+namespace ASL.LivingGrid.WebAdminPanel.Models;
+
+public class TranslationSuggestionRequest
+{
+    public string Text { get; set; } = string.Empty;
+    public string SourceCulture { get; set; } = "en";
+    public string TargetCulture { get; set; } = "az";
+}

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Program.cs
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Program.cs
@@ -129,6 +129,7 @@ public class Program
         services.AddScoped<IWireframePageBuilderService, WireframePageBuilderService>();
         services.AddScoped<IThemeService, ThemeService>();
         services.AddScoped<INavigationService, NavigationService>();
+        services.AddScoped<ITranslationWorkflowService, TranslationWorkflowService>();
 
         // Add HTTP Client for external API calls
         services.AddHttpClient();
@@ -239,6 +240,11 @@ public class Program
         {
             var created = await svc.SubmitRequestAsync(req.Key, req.Culture, req.ProposedValue ?? string.Empty, user.Identity?.Name ?? "anon");
             return Results.Ok(created);
+        });
+        trGroup.MapPost("/suggest", async (TranslationSuggestionRequest req, ITranslationWorkflowService svc) =>
+        {
+            var result = await svc.SuggestAsync(req.Text, req.SourceCulture, req.TargetCulture);
+            return Results.Ok(new { suggestion = result });
         });
         trGroup.MapPost("/approve/{id}", async (Guid id, ITranslationWorkflowService svc, ClaimsPrincipal user) =>
         {

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Services/ITranslationWorkflowService.cs
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Services/ITranslationWorkflowService.cs
@@ -6,5 +6,6 @@ public interface ITranslationWorkflowService
 {
     Task<TranslationRequest> SubmitRequestAsync(string key, string culture, string proposedValue, string requestedBy);
     Task ApproveRequestAsync(Guid id, string approvedBy, bool apply);
+    Task<string?> SuggestAsync(string text, string sourceCulture, string targetCulture);
     Task<IEnumerable<TranslationRequest>> GetPendingRequestsAsync();
 }

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Services/TranslationWorkflowService.cs
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Services/TranslationWorkflowService.cs
@@ -1,6 +1,11 @@
 using ASL.LivingGrid.WebAdminPanel.Data;
 using ASL.LivingGrid.WebAdminPanel.Models;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
 
 namespace ASL.LivingGrid.WebAdminPanel.Services;
 
@@ -9,12 +14,24 @@ public class TranslationWorkflowService : ITranslationWorkflowService
     private readonly ApplicationDbContext _context;
     private readonly ILocalizationService _localizationService;
     private readonly IAuditService _audit;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<TranslationWorkflowService> _logger;
 
-    public TranslationWorkflowService(ApplicationDbContext context, ILocalizationService localizationService, IAuditService audit)
+    public TranslationWorkflowService(
+        ApplicationDbContext context,
+        ILocalizationService localizationService,
+        IAuditService audit,
+        IHttpClientFactory httpClientFactory,
+        IConfiguration configuration,
+        ILogger<TranslationWorkflowService> logger)
     {
         _context = context;
         _localizationService = localizationService;
         _audit = audit;
+        _httpClientFactory = httpClientFactory;
+        _configuration = configuration;
+        _logger = logger;
     }
 
     public async Task<TranslationRequest> SubmitRequestAsync(string key, string culture, string proposedValue, string requestedBy)
@@ -50,6 +67,68 @@ public class TranslationWorkflowService : ITranslationWorkflowService
         }
 
         await _audit.LogAsync("Approve", nameof(TranslationRequest), id.ToString(), approvedBy, approvedBy, null, req);
+    }
+
+    public async Task<string?> SuggestAsync(string text, string sourceCulture, string targetCulture)
+    {
+        var provider = _configuration.GetValue<string>("Translation:Provider") ?? "OpenAI";
+        try
+        {
+            var client = _httpClientFactory.CreateClient();
+            if (string.Equals(provider, "OpenAI", StringComparison.OrdinalIgnoreCase))
+            {
+                var endpoint = _configuration.GetValue<string>("Translation:Endpoint") ?? "https://api.openai.com/v1/chat/completions";
+                var apiKey = _configuration.GetValue<string>("Translation:ApiKey");
+                var model = _configuration.GetValue<string>("Translation:Model") ?? "gpt-3.5-turbo";
+
+                using var request = new HttpRequestMessage(HttpMethod.Post, endpoint);
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+                var payload = new
+                {
+                    model,
+                    messages = new[]
+                    {
+                        new { role = "system", content = $"Translate the following text from {sourceCulture} to {targetCulture}." },
+                        new { role = "user", content = text }
+                    }
+                };
+                request.Content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
+
+                using var response = await client.SendAsync(request);
+                response.EnsureSuccessStatusCode();
+                var json = await response.Content.ReadAsStringAsync();
+                using var doc = JsonDocument.Parse(json);
+                var result = doc.RootElement.GetProperty("choices")[0].GetProperty("message").GetProperty("content").GetString();
+                return result?.Trim();
+            }
+            else if (string.Equals(provider, "DeepL", StringComparison.OrdinalIgnoreCase))
+            {
+                var endpoint = _configuration.GetValue<string>("Translation:Endpoint") ?? "https://api.deepl.com/v2/translate";
+                var apiKey = _configuration.GetValue<string>("Translation:ApiKey");
+                var query = new Dictionary<string, string>
+                {
+                    ["auth_key"] = apiKey ?? string.Empty,
+                    ["text"] = text,
+                    ["source_lang"] = sourceCulture.ToUpperInvariant(),
+                    ["target_lang"] = targetCulture.ToUpperInvariant()
+                };
+                using var content = new FormUrlEncodedContent(query);
+                using var response = await client.PostAsync(endpoint, content);
+                response.EnsureSuccessStatusCode();
+                var json = await response.Content.ReadAsStringAsync();
+                using var doc = JsonDocument.Parse(json);
+                var result = doc.RootElement.GetProperty("translations")[0].GetProperty("text").GetString();
+                return result?.Trim();
+            }
+
+            _logger.LogWarning("Unknown translation provider: {Provider}", provider);
+            return null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error requesting translation from {Provider}", provider);
+            return null;
+        }
     }
 
     public async Task<IEnumerable<TranslationRequest>> GetPendingRequestsAsync()

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/appsettings.json
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/appsettings.json
@@ -48,5 +48,11 @@
     "DefaultLanguage": "az",
     "SupportedLanguages": ["az", "en", "tr", "ru"]
   },
+  "Translation": {
+    "Provider": "OpenAI",
+    "ApiKey": "",
+    "Endpoint": "https://api.openai.com/v1/chat/completions",
+    "Model": "gpt-3.5-turbo"
+  },
   "BackupDirectory": "backups"
 }


### PR DESCRIPTION
## Summary
- implement translation suggestions with OpenAI/DeepL support
- expose `/api/translationrequests/suggest` endpoint
- add translation configuration in appsettings
- document new setup in LocalizationBook

## Testing
- `dotnet build` *(failed: compatible .NET SDK not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f073386488332a088fe10ad7439c0