### PR TITLE
Add translation request statuses

### DIFF
--- a/For Developer/LocalizationBook/README.md
+++ b/For Developer/LocalizationBook/README.md
@@ -8,6 +8,7 @@ Bu kitab WebAdminPanel modulunda tərcümə idarəçiliyi və dil paketlərinin 
 - JSON formatında import və export
 - REST API vasitəsilə dil paketlərinin idarəsi
 - AI tərcümə təklifləri üçün `TranslationWorkflowService.SuggestAsync` metodu
+- Tərcümə sorğularının vəziyyətləri: **Machine**, **Human**, **PendingReview**, **Approved**
 
 ## İstifadə Qaydası
 1. `/languagepacks` səhifəsinə keçid edərək mövcud dillərin siyahısını görün.

--- a/Frontend_TODO.md
+++ b/Frontend_TODO.md
@@ -123,7 +123,7 @@ Hər dəfə deployment və arxitektura ilə bağlı dəyişiklik və ya yeni bir
     - [x] Crowdsource editor: role-based translation request & approval workflow
 
     - [x] AI translation suggestions (OpenAI, Google, DeepL, custom LLM)
-    - [ ] Translation status: “machine”, “human”, “pending review”, “approved”
+    - [x] Translation status: “machine”, “human”, “pending review”, “approved”
     - [x] Activity log for all translation events
     - [ ] Proofreading workflow (review, approve, escalate issues)
 - [ ] **Coverage & Quality Assurance**

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Migrations/20240706000000_AddPendingReviewStatus.cs
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Migrations/20240706000000_AddPendingReviewStatus.cs
@@ -1,0 +1,16 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace ASL.LivingGrid.WebAdminPanel.Migrations;
+
+public partial class AddPendingReviewStatus : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        // No schema changes required; enum value renamed to PendingReview
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        // No schema changes to revert
+    }
+}

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Models/TranslationRequest.cs
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Models/TranslationRequest.cs
@@ -17,7 +17,7 @@ public class TranslationRequest : BaseEntity
     [StringLength(100)]
     public string RequestedBy { get; set; } = string.Empty;
 
-    public TranslationRequestStatus Status { get; set; } = TranslationRequestStatus.Pending;
+    public TranslationRequestStatus Status { get; set; } = TranslationRequestStatus.PendingReview;
 
     [StringLength(100)]
     public string? ApprovedBy { get; set; }
@@ -29,6 +29,6 @@ public enum TranslationRequestStatus
 {
     Machine,
     Human,
-    Pending,
+    PendingReview,
     Approved
 }

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Program.cs
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Program.cs
@@ -236,6 +236,8 @@ public class Program
 
         var trGroup = app.MapGroup("/api/translationrequests");
         trGroup.MapGet("/pending", async (ITranslationWorkflowService svc) => Results.Ok(await svc.GetPendingRequestsAsync()));
+        trGroup.MapGet("/status/{status}", async (TranslationRequestStatus status, ITranslationWorkflowService svc) =>
+            Results.Ok(await svc.GetRequestsByStatusAsync(status)));
         trGroup.MapPost("/submit", async (TranslationRequest req, ITranslationWorkflowService svc, ClaimsPrincipal user) =>
         {
             var created = await svc.SubmitRequestAsync(req.Key, req.Culture, req.ProposedValue ?? string.Empty, user.Identity?.Name ?? "anon");

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Services/ITranslationWorkflowService.cs
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Services/ITranslationWorkflowService.cs
@@ -8,5 +8,6 @@ public interface ITranslationWorkflowService
     Task ApproveRequestAsync(Guid id, string approvedBy, bool apply);
     Task<string?> SuggestAsync(string text, string sourceCulture, string targetCulture);
     Task<IEnumerable<TranslationRequest>> GetPendingRequestsAsync();
+    Task<IEnumerable<TranslationRequest>> GetRequestsByStatusAsync(TranslationRequestStatus status);
     Task UpdateStatusAsync(Guid id, TranslationRequestStatus status, string updatedBy);
 }

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Services/TranslationWorkflowService.cs
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Services/TranslationWorkflowService.cs
@@ -43,6 +43,7 @@ public class TranslationWorkflowService : ITranslationWorkflowService
             Culture = culture,
             ProposedValue = proposedValue,
             RequestedBy = requestedBy,
+            Status = TranslationRequestStatus.PendingReview,
             CreatedAt = DateTime.UtcNow
         };
         _context.TranslationRequests.Add(req);
@@ -187,7 +188,15 @@ public class TranslationWorkflowService : ITranslationWorkflowService
     public async Task<IEnumerable<TranslationRequest>> GetPendingRequestsAsync()
     {
         return await _context.TranslationRequests
-            .Where(r => r.Status == TranslationRequestStatus.Pending)
+            .Where(r => r.Status == TranslationRequestStatus.PendingReview)
+            .OrderBy(r => r.CreatedAt)
+            .ToListAsync();
+    }
+
+    public async Task<IEnumerable<TranslationRequest>> GetRequestsByStatusAsync(TranslationRequestStatus status)
+    {
+        return await _context.TranslationRequests
+            .Where(r => r.Status == status)
             .OrderBy(r => r.CreatedAt)
             .ToListAsync();
     }


### PR DESCRIPTION
## Summary
- rename `Pending` to `PendingReview` status
- expose a status filter API for translation requests
- seed request status on create and update service logic
- add EF migration for status rename
- document translation statuses in LocalizationBook
- check off TODO for translation status

## Testing
- `dotnet build ASL.LivingGrid.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f0c43c78c83328bf2a5741f716ee5