### PR TITLE
Implement role-based navigation with tenant overrides

### DIFF
--- a/For Developer/UXUIBook/README.md
+++ b/For Developer/UXUIBook/README.md
@@ -34,6 +34,16 @@ Bu sənəd WebAdminPanel modulunun istifadəçi təcrübəsi və dizayn prinsipl
 - Vidjet əlavə olunduqdan sonra yerləşdirməni dəyişmək və ya silmək üçün sadə drag-and-drop funksiyası aktivdir.
 - Hazır düzən `dashboardDesigner.js` skripti vasitəsilə brauzer yaddaşında saxlanılır və növbəti açılışda bərpa olunur.
 
+### NavigationService ilə Rol və Tenant Menyusu
+- `NavigationService` artıq `RoleBasedUiService` vasitəsilə istifadəçi rollarına uyğun menyu elementlərini qaytarır.
+- Tenant üçün `menuitems.{tenant}.json` faylı tapılarsa, əsas menyunu həmin fayl əvəz edir.
+- `NavMenu` komponenti bu servisdən `GetMenuItemsAsync(user, tenantId)` çağırışı ilə siyahını alır.
+
+### WYSIWYG Redaktor
+- `VisualEditor` səhifəsi `contenteditable` əsaslı sadə redaktorla yenilənib.
+- `wysiwyg.js` skripti daxilində yazılan mətnləri dərhal ifrəmədə göstərir.
+- **B**, **I**, **U** düymələri `execCommand` ilə mətni formatlayır.
+
 ## Gələcək İnkişaf
 - Tam WCAG 2.1 uyğunluğunun avtomatik yoxlanılması üçün genişlənmiş audit modulu.
 - Fərdi şirkətlər üçün rəng palitrası və loqo yükləmə imkanları.

--- a/Frontend_TODO.md
+++ b/Frontend_TODO.md
@@ -183,9 +183,9 @@ Bu modulda və ya alt modulda hər bir yeni funksiya, əlavə, düzəliş və ya
 - [x] Visual wireframe/page builder - 2025.06.15 - AI: WireframePageBuilderService with comprehensive visual design, templating, code generation, and preview capabilities
 - [ ] Real-time translation manager, theme/color/logo editor
 - [ ] Accessibility compliance check
-- [ ] **Per-role navigation structure and menu editing**
+ - [x] **Per-role navigation structure and menu editing** - 2025-06-16 - AI: NavigationService filtrates menu by user role
 - [ ] **Multi-level menu logic (mega menu, dynamic pop-out, favorites, search)**
-- [ ] **Tenant/company custom menus and layout overrides**
+ - [x] **Tenant/company custom menus and layout overrides** - 2025-06-16 - AI: NavigationService reads menuitems.{tenant}.json
 
 **For Developer qovluğu və Book:**  
 Bu modulda və ya alt modulda hər bir yeni funksiya, əlavə, düzəliş və ya texniki dəyişiklik olduqda, `For Developer` qovluğunda həmin modul üçün Book yenilənir:

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Components/Layout/NavMenu.razor
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Components/Layout/NavMenu.razor
@@ -64,18 +64,9 @@
             localizedStrings["Navigation.LocalizationCoverage"] = "Tərcümə Örtüyü";
         }
 
-        var allItems = await NavService.GetMenuItemsAsync();
         var authState = await AuthProvider.GetAuthenticationStateAsync();
         var user = authState.User;
-        var list = new List<NavigationItem>();
-        foreach (var item in allItems)
-        {
-            if (await RoleUi.HasAccessAsync(item.Key, user))
-            {
-                list.Add(item);
-            }
-        }
-        menuItems = list;
+        menuItems = await NavService.GetMenuItemsAsync(user);
     }
 
     private async Task SimulateRole(ChangeEventArgs e)

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Components/Pages/VisualEditor.razor
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Components/Pages/VisualEditor.razor
@@ -1,10 +1,15 @@
 @page "/visual-editor"
 @inject IJSRuntime JS
 
-<h3>Realtime Visual Editor</h3>
+<h3>WYSIWYG Səhifə Redaktoru</h3>
 <div class="row">
     <div class="col-md-6">
-        <textarea class="form-control" style="height:300px" @bind="html" @bind:event="oninput"></textarea>
+        <div class="btn-group mb-2" role="group">
+            <button class="btn btn-sm btn-secondary" @onclick="() => Format('bold')">B</button>
+            <button class="btn btn-sm btn-secondary" @onclick="() => Format('italic')">I</button>
+            <button class="btn btn-sm btn-secondary" @onclick="() => Format('underline')">U</button>
+        </div>
+        <div id="editor" class="form-control" style="height:250px" contenteditable="true"></div>
     </div>
     <div class="col-md-6">
         <iframe id="preview" class="w-100" style="height:300px"></iframe>
@@ -12,12 +17,16 @@
 </div>
 
 @code {
-    private string html = "<h1>Hello</h1>";
-
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        await JS.InvokeVoidAsync("eval", $"document.getElementById('preview').contentDocument.body.innerHTML = `{EscapeHtml(html)}`;");
+        if (firstRender)
+        {
+            await JS.InvokeVoidAsync("wysiwyg.init");
+        }
     }
 
-    private static string EscapeHtml(string input) => input.Replace("`", "\\`");
+    private async Task Format(string cmd)
+    {
+        await JS.InvokeVoidAsync("wysiwyg.command", cmd);
+    }
 }

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Pages/Shared/_Layout.cshtml
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Pages/Shared/_Layout.cshtml
@@ -30,6 +30,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-z9WtwE9q3YJPHytAOxT3OYaL6VZr5EKeosFVJeFt3PcTJS3BM4tiTqcKoy0eZZ+j" crossorigin="anonymous"></script>
     <script src="js/uiAudit.js"></script>
     <script src="js/toast.js"></script>
+    <script src="js/wysiwyg.js"></script>
     <script src="_framework/blazor.server.js"></script>
 </body>
 </html>

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Program.cs
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Program.cs
@@ -127,11 +127,11 @@ public class Program
         services.AddScoped<IAdvancedRollbackService, AdvancedRollbackService>();
         services.AddScoped<IWireframePageBuilderService, WireframePageBuilderService>();
         services.AddScoped<IThemeService, ThemeService>();
+        services.AddScoped<IRoleBasedUiService, RoleBasedUiService>();
         services.AddScoped<INavigationService, NavigationService>();
         services.AddScoped<ITranslationWorkflowService, TranslationWorkflowService>();
         services.AddScoped<IThemeMarketplaceService, ThemeMarketplaceService>();
         services.AddScoped<ILayoutMarketplaceService, LayoutMarketplaceService>();
-        services.AddScoped<IRoleBasedUiService, RoleBasedUiService>();
         services.AddScoped<IModuleCustomizationService, ModuleCustomizationService>();
         services.AddScoped<IFeedbackService, FeedbackService>();
         services.AddScoped<ISessionPersistenceService, SessionPersistenceService>();

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Services/INavigationService.cs
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Services/INavigationService.cs
@@ -1,8 +1,9 @@
 using ASL.LivingGrid.WebAdminPanel.Models;
+using System.Security.Claims;
 
 namespace ASL.LivingGrid.WebAdminPanel.Services;
 
 public interface INavigationService
 {
-    Task<IEnumerable<NavigationItem>> GetMenuItemsAsync();
+    Task<IEnumerable<NavigationItem>> GetMenuItemsAsync(ClaimsPrincipal? user = null, string? tenantId = null);
 }

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/menuitems.demo.json
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/menuitems.demo.json
@@ -1,0 +1,6 @@
+[
+  { "Key": "Navigation.Dashboard", "Url": "", "Icon": "oi oi-home" },
+  { "Key": "Navigation.Users", "Url": "users", "Icon": "oi oi-person" },
+  { "Key": "Navigation.Settings", "Url": "settings", "Icon": "oi oi-cog" },
+  { "Key": "Navigation.Feedback", "Url": "feedback", "Icon": "oi oi-comment-square" }
+]

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/wwwroot/js/wysiwyg.js
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/wwwroot/js/wysiwyg.js
@@ -1,0 +1,15 @@
+window.wysiwyg = {
+    init: function() {
+        const editor = document.getElementById('editor');
+        const preview = document.getElementById('preview');
+        if (!editor || !preview) return;
+        const update = () => {
+            preview.contentDocument.body.innerHTML = editor.innerHTML;
+        };
+        editor.addEventListener('input', update);
+        update();
+    },
+    command: function(cmd) {
+        document.execCommand(cmd, false, null);
+    }
+};


### PR DESCRIPTION
## Summary
- expand `NavigationService` to filter by user role and tenant-specific menu files
- load filtered navigation in `NavMenu`
- add a simple WYSIWYG page editor and helper script
- document the features in `UXUIBook`
- mark completed items in `Frontend_TODO`

## Testing
- `dotnet build ASL.LivingGrid.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f2e486e588332b439ac09996219f1