### PR TITLE
Implement translation rejection flow

### DIFF
--- a/For Developer/LocalizationBook/README.md
+++ b/For Developer/LocalizationBook/README.md
@@ -8,14 +8,15 @@ Bu kitab WebAdminPanel modulunda tərcümə idarəçiliyi və dil paketlərinin 
 - JSON formatında import və export
 - REST API vasitəsilə dil paketlərinin idarəsi
 - AI tərcümə təklifləri üçün `TranslationWorkflowService.SuggestAsync` metodu
-- Tərcümə sorğularının vəziyyətləri: **Machine**, **Human**, **PendingReview**, **Approved**
+- Tərcümə sorğularının vəziyyətləri: **Machine**, **Human**, **PendingReview**, **Approved**, **Rejected**
 
 ## Statusların mənası
 - **Machine** – maşın tərcüməsi, ilkin dəyər kimi əlavə edilir və yoxlamaya göndərilir.
 - **Human** – insan tərəfindən daxil edilən tərcümə, moderasiya tələb edir.
 - **PendingReview** – tərcümə redaktorun təsdiqini gözləyir.
 - **Approved** – təsdiqlənmiş tərcümə və dil paketində aktivdir.
-- `TranslationRequest` modelinə `ReviewerComments` və `Escalate` sahələri əlavə olunub
+- **Rejected** – moderator tərəfindən rədd edilmiş və tətbiq olunmayan tərcümə.
+- `TranslationRequest` modelinə `ReviewerComments`, `Escalate`, `RejectedBy` və `RejectedAt` sahələri əlavə olunub
 
 
 ## İstifadə Qaydası
@@ -37,5 +38,9 @@ Bu kitab WebAdminPanel modulunda tərcümə idarəçiliyi və dil paketlərinin 
    model və region dəyərlərini doldurmağı unutmayın. `Custom` rejimində endpoint
    sizin daxili servisinizə yönəldilir və lazım olduqda `ApiKey` başlıqda `Bearer`
    kimi ötürülür.
+
+10. Moderatorlar üçün `/pendingreviews` Blazor səhifəsi mövcuddur. Bu səhifə
+    gözləyən sorğuların siyahısını göstərir və hər sorğu üçün **Approve** və
+    **Reject** düymələri vasitəsilə yuxarıdakı API-lərə sorğu göndərir.
 
 Bu sənəd daim yenilənəcək.

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Components/Pages/PendingReviews.razor
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Components/Pages/PendingReviews.razor
@@ -1,5 +1,8 @@
 @page "/pendingreviews"
+@using ASL.LivingGrid.WebAdminPanel.Models
+@using System.Net.Http.Json
 @inject ITranslationWorkflowService WorkflowService
+@inject HttpClient Http
 
 <PageTitle>Pending Reviews</PageTitle>
 
@@ -22,6 +25,7 @@ else
                 <th>Proposed</th>
                 <th>Culture</th>
                 <th>Requested By</th>
+                <th></th>
             </tr>
         </thead>
         <tbody>
@@ -32,6 +36,10 @@ else
                     <td>@r.ProposedValue</td>
                     <td>@r.Culture</td>
                     <td>@r.RequestedBy</td>
+                    <td>
+                        <button class="btn btn-sm btn-success me-2" @onclick="() => Approve(r.Id)">Approve</button>
+                        <button class="btn btn-sm btn-danger" @onclick="() => Reject(r.Id)">Reject</button>
+                    </td>
                 </tr>
             }
         </tbody>
@@ -44,6 +52,21 @@ else
     protected override async Task OnInitializedAsync()
     {
         requests = (await WorkflowService.GetPendingRequestsAsync()).ToList();
+    }
+
+    private async Task Approve(Guid id)
+    {
+        await Http.PostAsync($"/api/translationrequests/approve/{id}", null);
+        if (requests is not null)
+            requests.RemoveAll(r => r.Id == id);
+    }
+
+    private async Task Reject(Guid id)
+    {
+        var payload = new TranslationReviewRequest { Accept = false };
+        await Http.PostAsJsonAsync($"/api/translationrequests/reject/{id}", payload);
+        if (requests is not null)
+            requests.RemoveAll(r => r.Id == id);
     }
 }
 

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Migrations/20240825000000_AddRejectedStatus.cs
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Migrations/20240825000000_AddRejectedStatus.cs
@@ -1,0 +1,33 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace ASL.LivingGrid.WebAdminPanel.Migrations;
+
+public partial class AddRejectedStatus : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<string>(
+            name: "RejectedBy",
+            table: "TranslationRequests",
+            type: "nvarchar(100)",
+            maxLength: 100,
+            nullable: true);
+
+        migrationBuilder.AddColumn<DateTime>(
+            name: "RejectedAt",
+            table: "TranslationRequests",
+            nullable: true);
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(
+            name: "RejectedBy",
+            table: "TranslationRequests");
+
+        migrationBuilder.DropColumn(
+            name: "RejectedAt",
+            table: "TranslationRequests");
+    }
+}

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Models/TranslationRequest.cs
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Models/TranslationRequest.cs
@@ -24,6 +24,11 @@ public class TranslationRequest : BaseEntity
 
     public DateTime? ApprovedAt { get; set; }
 
+    [StringLength(100)]
+    public string? RejectedBy { get; set; }
+
+    public DateTime? RejectedAt { get; set; }
+
     [StringLength(500)]
     public string? ReviewerComments { get; set; }
 
@@ -39,5 +44,7 @@ public enum TranslationRequestStatus
     /// <summary>Translation requires proofreading before approval.</summary>
     PendingReview,
     /// <summary>Translation approved and applied.</summary>
-    Approved
+    Approved,
+    /// <summary>Translation was reviewed and rejected.</summary>
+    Rejected
 }

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Services/TranslationWorkflowService.cs
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Services/TranslationWorkflowService.cs
@@ -61,6 +61,8 @@ public class TranslationWorkflowService : ITranslationWorkflowService
         req.Status = TranslationRequestStatus.Approved;
         req.ApprovedBy = approvedBy;
         req.ApprovedAt = DateTime.UtcNow;
+        req.RejectedBy = null;
+        req.RejectedAt = null;
         await _context.SaveChangesAsync();
 
         if (apply && req.ProposedValue != null)
@@ -95,6 +97,8 @@ public class TranslationWorkflowService : ITranslationWorkflowService
             req.Status = TranslationRequestStatus.Approved;
             req.ApprovedBy = reviewer;
             req.ApprovedAt = DateTime.UtcNow;
+            req.RejectedBy = null;
+            req.RejectedAt = null;
 
             if (req.ProposedValue is not null)
             {
@@ -103,7 +107,11 @@ public class TranslationWorkflowService : ITranslationWorkflowService
         }
         else
         {
-            req.Status = TranslationRequestStatus.Human;
+            req.Status = TranslationRequestStatus.Rejected;
+            req.RejectedBy = reviewer;
+            req.RejectedAt = DateTime.UtcNow;
+            req.ApprovedBy = null;
+            req.ApprovedAt = null;
         }
 
         await _context.SaveChangesAsync();


### PR DESCRIPTION
## Summary
- expand translation request model with `RejectedBy` and `RejectedAt` fields and new `Rejected` status
- handle rejection in translation workflow service
- update pending reviews page with approve and reject actions
- document updated workflow in LocalizationBook
- add EF migration for rejected status columns

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-9.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_684f3053ff348332ba21196fa75c0db5