### PR TITLE
Add documentation summaries for hosting modes and theme marketplace

### DIFF
--- a/For Developer/DeploymentBook/README.md
+++ b/For Developer/DeploymentBook/README.md
@@ -1,6 +1,12 @@
 # DeploymentBook
 
 Bu sənəd WebAdminPanel modulunun yerləşdirilməsi üçün addımları və rejimləri izah edir.
+### Qısa xülasə
+Hazırki versiyada dörd yerləşdirmə rejimi sınanmış və istifadəyə hazırdır:
+1. **Standalone** (.exe) – Kestrel prosesi kimi çalışır.
+2. **WebServer** – IIS, Apache və ya Nginx üzərindən reverse proxy.
+3. **Docker** – hazır Dockerfile ilə container kimi.
+4. **Serverless Cloud Functions** – `cloudFunctions.json` və `CloudFunctionService`-dən istifadə.
 
 ## Hosting rejimləri
 - **Standalone (.exe)** – Kestrel üzərində işləyən və Windows servis kimi işə düşə bilən rejim.

--- a/For Developer/UXUIBook/README.md
+++ b/For Developer/UXUIBook/README.md
@@ -1,6 +1,11 @@
 # UXUIBook
 
 Bu sənəd WebAdminPanel modulunun istifadəçi təcrübəsi və dizayn prinsiplərini izah edir.
+### Qısa xülasə
+`Theme Marketplace` səhifəsi aktivdir və aşağıdakı imkanları təqdim edir:
+- Mövcud temaları siyahıdan seçib dərhal tətbiq etmək.
+- Yeni tema faylı yükləyib `/api/themes/import/{id}` endpointi ilə aktivləşdirmək.
+- İstənilən temanı ixrac edib başqa mühitdə istifadə etmək.
 
 ## Məqsəd
 - İstifadəçilərə bütün cihazlarda rahat görünən adaptiv interfeys təqdim etmək.

--- a/Frontend_TODO.md
+++ b/Frontend_TODO.md
@@ -84,6 +84,7 @@
 
 **For Developer qovluğu və Book:**  
 Hər dəfə deployment və arxitektura ilə bağlı dəyişiklik və ya yeni bir seçim əlavə olunduqda, `For Developer` qovluğunda ən müasir documentation texnologiyası (məsələn, Docusaurus və ya Docsify) ilə `DeploymentBook` yaradılmalı və ya yenilənməlidir. Burada **bütün addımlar, seçim səbəbləri, risk və üstünlüklər, istifadə və idarəetmə qaydaları, gələcək inkişaf variantları** yalnız Azərbaycan dilində (terminlər istisna) izah olunmalıdır.
+- [x] DeploymentBook-a hosting rejimlərinin xülasəsi əlavə olundu - 2025-06-17 - AI
 ---
 
 ## 1.1. Design & User Experience (UX/UI Principles)
@@ -104,6 +105,7 @@ Hər dəfə deployment və arxitektura ilə bağlı dəyişiklik və ya yeni bir
 
 **For Developer qovluğu və Book:**  
 `For Developer` qovluğunda `UXUIBook` yaradılmalı və ya mövcud olan sənəd hər dəyişiklikdə yenilənməlidir. Burada dizayn qərarlarının səbəbləri, əsas UI/UX prinsipləri, istifadəçi təcrübəsinin niyə belə seçildiyi, hər bir özəlliyin istifadə və idarəetmə qaydası, audit və gələcək inkişaf planları **ətraflı və yalnız Azərbaycan dilində** yazılmalıdır.
+- [x] UXUIBook-a Tema Marketplace istifadəsinin xülasəsi əlavə olundu - 2025-06-17 - AI
 ---
 
 ### 1.1.1. Multi-Language & Translation Lifecycle Management (Enterprise Detailed)


### PR DESCRIPTION
## Summary
- summarize hosting modes in DeploymentBook
- summarize theme marketplace usage in UXUIBook
- reference docs updates in Frontend_TODO checklist

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f32f9a38c8332984d6b3327a0fa63