### PR TITLE
Implement translation preview

### DIFF
--- a/For Developer/LocalizationBook/README.md
+++ b/For Developer/LocalizationBook/README.md
@@ -42,5 +42,9 @@ Bu kitab WebAdminPanel modulunda tərcümə idarəçiliyi və dil paketlərinin 
 10. Moderatorlar üçün `/pendingreviews` Blazor səhifəsi mövcuddur. Bu səhifə
     gözləyən sorğuların siyahısını göstərir və hər sorğu üçün **Approve** və
     **Reject** düymələri vasitəsilə yuxarıdakı API-lərə sorğu göndərir.
+11. Hər bir sorğu üçün **Preview** düyməsi mövcuddur. Bu düymə təklif edilən
+    tərcüməni `/translationpreview` səhifəsində seçilmiş dil və açarla birlikdə
+    real vaxtda göstərir. İstifadəçi tərcüməni yayımlamadan əvvəl necə
+    göründüyünü sınaqdan keçirə bilir.
 
 Bu sənəd daim yenilənəcək.

--- a/Frontend_TODO.md
+++ b/Frontend_TODO.md
@@ -130,7 +130,7 @@ Hər dəfə deployment və arxitektura ilə bağlı dəyişiklik və ya yeni bir
 - [ ] **Coverage & Quality Assurance**
     - [x] Coverage dashboard (% complete, missing keys, per-module coverage)
     - [x] Live alert for untranslated/missing/incomplete/invalid placeholders
-    - [ ] Context preview: see translation in UI before publish
+    - [x] Context preview: see translation in UI before publish - 2025-06-17 - AI
     - [ ] Consistency checker: identical terms across modules, placeholder validation
     - [ ] Length/overflow check (UI fit)
 - [ ] **Localization Customization**

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Components/Pages/PendingReviews.razor
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Components/Pages/PendingReviews.razor
@@ -37,6 +37,7 @@ else
                     <td>@r.Culture</td>
                     <td>@r.RequestedBy</td>
                     <td>
+                        <a class="btn btn-sm btn-secondary me-2" href="/translationpreview?key=@r.Key&culture=@r.Culture&proposedValue=@Uri.EscapeDataString(r.ProposedValue ?? string.Empty)">Preview</a>
                         <button class="btn btn-sm btn-success me-2" @onclick="() => Approve(r.Id)">Approve</button>
                         <button class="btn btn-sm btn-danger" @onclick="() => Reject(r.Id)">Reject</button>
                     </td>

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Components/Pages/TranslationPreview.razor
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Components/Pages/TranslationPreview.razor
@@ -1,0 +1,37 @@
+@page "/translationpreview"
+@inject NavigationManager Nav
+@inject ILocalizationService LocalizationService
+
+<h3>Translation Preview</h3>
+
+@if (string.IsNullOrWhiteSpace(Key))
+{
+    <p class="text-warning">No key specified.</p>
+}
+else
+{
+    <p><strong>Key:</strong> @Key</p>
+    <p><strong>Culture:</strong> @Culture</p>
+    <div class="border rounded p-3 my-3">
+        @previewValue
+    </div>
+}
+
+@code {
+    private string? previewValue;
+    [Parameter] public string? Key { get; set; }
+    [Parameter] public string Culture { get; set; } = "az";
+    [Parameter] public string? ProposedValue { get; set; }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (!string.IsNullOrWhiteSpace(ProposedValue))
+        {
+            previewValue = ProposedValue;
+        }
+        else if (!string.IsNullOrWhiteSpace(Key))
+        {
+            previewValue = await LocalizationService.GetStringAsync(Key!, Culture);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a simple TranslationPreview page
- link preview page from PendingReviews
- document preview workflow in LocalizationBook
- mark preview task as complete in Frontend_TODO

## Testing
- `dotnet build ASL.LivingGrid.sln -c Release` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684f35cdf6488332a26ba6dad35d018e