### PR TITLE
Fix sidebar collapse toggle

### DIFF
--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Components/Layout/NavMenu.razor
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Components/Layout/NavMenu.razor
@@ -14,7 +14,7 @@
 </div>
 
 
-<button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#sidebarMenuContent" aria-controls="sidebarMenuContent" aria-expanded="false" aria-label="Toggle navigation">
+<button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#sidebarMenu" aria-controls="sidebarMenu" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
 </button>
 


### PR DESCRIPTION
## Summary
- make the sidebar collapse button target `#sidebarMenu`

## Testing
- `dotnet test --no-build -v m` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684f42c91c508332b16f56e009545e3f