### PR TITLE
Update license references to MIT

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -19,7 +19,7 @@
     <PackageProjectUrl>https://github.com/asl/livinggrid</PackageProjectUrl>
     <RepositoryUrl>https://github.com/asl/livinggrid</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageLicenseExpression>Proprietary</PackageLicenseExpression>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -100,4 +100,4 @@ Please read `Read before you start working.md` before beginning any development 
 
 ## License
 
-All rights reserved. Enterprise solution by ASL.
+This project is released under the [MIT License](LICENSE.txt).


### PR DESCRIPTION
## Summary
- declare MIT license in README
- use MIT expression in Directory.Build.props

## Testing
- `dotnet build ASL.LivingGrid.sln -c Release` *(fails: Microsoft.EntityFrameworkCore.InMemory version conflict)*

------
https://chatgpt.com/codex/tasks/task_e_684fb0e57984833284f7b7054e180074