### PR TITLE
Add CI workflow for .NET 9

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,16 @@
+name: .NET
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+      - run: dotnet build ASL.LivingGrid.sln
+      - run: dotnet test ASL.LivingGrid.sln --no-build


### PR DESCRIPTION
## Summary
- add dotnet.yml GitHub Action using actions/setup-dotnet to install .NET 9

## Testing
- `dotnet build ASL.LivingGrid.sln --configuration Release`
- `dotnet test ASL.LivingGrid.sln --no-build` *(fails: argument invalid)*

------
https://chatgpt.com/codex/tasks/task_e_684fb276b4388332a196a8e79ebdc4ca