### PR TITLE
Rename ForceHttps configuration key

### DIFF
--- a/For Developer/DeploymentBook/README.md
+++ b/For Developer/DeploymentBook/README.md
@@ -15,6 +15,9 @@ Hazırki versiyada dörd yerləşdirmə rejimi sınanmış və istifadəyə haz�
 ### Konfiqurasiya
 `appsettings.json` faylında `Hosting:Mode` dəyərini dəyişərək rejim seçilir.
 Əlavə olaraq `BackupBeforeSwitch` və `AutoMigrate` parametrləri mövcuddur.
+HTTPS yönləndirməsini məcburi etmək üçün `Security:RequireHttps` açarını `true`
+edə bilərsiniz. Köhnə `ForceHttps` açarı hələ də tanınır, lakin gələcək
+versiyalarda çıxarılacaq.
 Komanda sətrindən `--standalone` və ya `--hosted` parametrini əlavə etməklə rejim dərhal dəyişdirilə bilər.
 
 ### Rejim dəyişdikdə

--- a/README.md
+++ b/README.md
@@ -87,6 +87,13 @@ dotnet build ASL.LivingGrid.sln
 
 Each module can be run independently from its own solution.
 
+### 6. Configuration
+
+To enforce HTTPS redirection when hosting the WebAdminPanel, set the
+`Security:RequireHttps` key in `appsettings.json` (or as an environment
+variable). The previous `ForceHttps` key is still accepted for backwards
+compatibility but will be removed in future versions.
+
 ## Development Workflow
 
 Please read `Read before you start working.md` before beginning any development work. The project follows strict Core Rules and workflow guidelines with progress tracking through TODO.md files. Continuous integration runs via GitHub Actions using `.github/workflows/dotnet.yml`.

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Program.cs
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Program.cs
@@ -190,7 +190,10 @@ public class Program
         }
 
 
-        if (!isStandaloneExe || app.Configuration.GetValue<bool>("ForceHttps"))
+        var requireHttps = app.Configuration.GetValue<bool?>("Security:RequireHttps");
+        var oldForceHttps = app.Configuration.GetValue<bool>("ForceHttps");
+
+        if (!isStandaloneExe || requireHttps.GetValueOrDefault(oldForceHttps))
         {
             app.UseHttpsRedirection();
         }

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Services/FirstLaunchDiagnosticService.cs
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Services/FirstLaunchDiagnosticService.cs
@@ -889,9 +889,10 @@ public class FirstLaunchDiagnosticService : IFirstLaunchDiagnosticService
             catch { }
         }
 
-        // Check HTTPS configuration
-        var httpsEnabled = _configuration.GetValue<bool>("ForceHttps", false);
-        if (httpsEnabled)
+        // Check HTTPS configuration (new key with legacy fallback)
+        var requireHttps = _configuration.GetValue<bool?>("Security:RequireHttps");
+        var oldForceHttps = _configuration.GetValue<bool>("ForceHttps", false);
+        if (requireHttps.GetValueOrDefault(oldForceHttps))
         {
             securityFeatures.Add("HTTPS enabled");
             securityScore++;


### PR DESCRIPTION
## Summary
- support new `Security:RequireHttps` config key with fallback
- document the new key

## Testing
- `dotnet build ASL.LivingGrid.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fb98af7c88332892ce411fad71087