### PR TITLE
Add Moq-based tests for services

### DIFF
--- a/Testing_TODO.md
+++ b/Testing_TODO.md
@@ -17,7 +17,7 @@
 ### Unit Test Tasks
 
 - [x] Write tests for core business logic
-- [ ] Mock API/services for isolated tests
+- [x] Mock API/services for isolated tests
 - [x] Test edge cases and failure scenarios
 - [x] Automated test run in CI pipeline
 

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel.Tests/Services/NavigationServiceTests.cs
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel.Tests/Services/NavigationServiceTests.cs
@@ -1,0 +1,36 @@
+using System.Security.Claims;
+using ASL.LivingGrid.WebAdminPanel.Models;
+using ASL.LivingGrid.WebAdminPanel.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace ASL.LivingGrid.WebAdminPanel.Tests.Services;
+
+public class NavigationServiceTests
+{
+    [Fact]
+    public async Task GetMenuItemsAsync_FiltersByRoleService()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+        var json = "[{\"Key\":\"Dashboard\",\"Url\":\"/\",\"Icon\":\"home\"},{\"Key\":\"Admin\",\"Url\":\"/admin\",\"Icon\":\"admin\"}]";
+        await File.WriteAllTextAsync(Path.Combine(tempDir, "menuitems.json"), json);
+
+        var envMock = new Mock<IWebHostEnvironment>();
+        envMock.SetupGet(e => e.ContentRootPath).Returns(tempDir);
+
+        var roleMock = new Mock<IRoleBasedUiService>();
+        roleMock.Setup(r => r.HasAccessAsync("Dashboard", It.IsAny<ClaimsPrincipal>())).ReturnsAsync(true);
+        roleMock.Setup(r => r.HasAccessAsync("Admin", It.IsAny<ClaimsPrincipal>())).ReturnsAsync(false);
+
+        var loggerMock = new Mock<ILogger<NavigationService>>();
+        var service = new NavigationService(loggerMock.Object, envMock.Object, roleMock.Object);
+
+        var user = new ClaimsPrincipal(new ClaimsIdentity());
+        var items = (await service.GetMenuItemsAsync(user)).ToList();
+
+        Assert.Single(items);
+        Assert.Equal("Dashboard", items[0].Key);
+    }
+}

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel.Tests/Services/ThemeMarketplaceServiceTests.cs
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel.Tests/Services/ThemeMarketplaceServiceTests.cs
@@ -1,0 +1,76 @@
+using System.Net;
+using System.Net.Http;
+using ASL.LivingGrid.WebAdminPanel.Models;
+using ASL.LivingGrid.WebAdminPanel.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace ASL.LivingGrid.WebAdminPanel.Tests.Services;
+
+public class ThemeMarketplaceServiceTests
+{
+    [Fact]
+    public async Task ListAvailableThemesAsync_ReadsFromLocalFile()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+        var jsonFile = Path.Combine(tempDir, "theme_marketplace.json");
+        var json = "[{"Id":"dark","Name":"Dark","Description":"Desc","DownloadUrl":"http://example.com/dark.css","PreviewImage":"img"}]";
+        await File.WriteAllTextAsync(jsonFile, json);
+
+        var envMock = new Mock<IWebHostEnvironment>();
+        envMock.SetupGet(e => e.ContentRootPath).Returns(tempDir);
+        envMock.SetupGet(e => e.WebRootPath).Returns(tempDir);
+
+        var clientFactoryMock = new Mock<IHttpClientFactory>();
+        var loggerMock = new Mock<ILogger<ThemeMarketplaceService>>();
+        var configuration = new ConfigurationBuilder().Build();
+
+        var service = new ThemeMarketplaceService(envMock.Object, clientFactoryMock.Object, loggerMock.Object, configuration);
+
+        var themes = await service.ListAvailableThemesAsync();
+
+        var theme = Assert.Single(themes);
+        Assert.Equal("dark", theme.Id);
+    }
+
+    [Fact]
+    public async Task ImportThemeAsync_DownloadsCssAndSavesFile()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(Path.Combine(tempDir, "css", "themes"));
+        var jsonFile = Path.Combine(tempDir, "theme_marketplace.json");
+        var json = "[{\"Id\":\"dark\",\"Name\":\"Dark\",\"Description\":\"Desc\",\"DownloadUrl\":\"http://example.com/dark.css\",\"PreviewImage\":\"img\"}]";
+        await File.WriteAllTextAsync(jsonFile, json);
+
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("body{}")
+            });
+        var httpClient = new HttpClient(handlerMock.Object);
+        var httpFactoryMock = new Mock<IHttpClientFactory>();
+        httpFactoryMock.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(httpClient);
+
+        var envMock = new Mock<IWebHostEnvironment>();
+        envMock.SetupGet(e => e.ContentRootPath).Returns(tempDir);
+        envMock.SetupGet(e => e.WebRootPath).Returns(tempDir);
+
+        var loggerMock = new Mock<ILogger<ThemeMarketplaceService>>();
+        var configuration = new ConfigurationBuilder().Build();
+        var service = new ThemeMarketplaceService(envMock.Object, httpFactoryMock.Object, loggerMock.Object, configuration);
+
+        var theme = await service.ImportThemeAsync("dark");
+
+        Assert.NotNull(theme);
+        var expectedFile = Path.Combine(tempDir, "css", "themes", "dark.css");
+        Assert.True(File.Exists(expectedFile));
+        var css = await File.ReadAllTextAsync(expectedFile);
+        Assert.Equal("body{}", css);
+    }
+}


### PR DESCRIPTION
## Summary
- test ThemeMarketplaceService using mocked HttpClient and env paths
- test NavigationService role-based filtering with Moq
- mark mocked API/services task complete in Testing_TODO

## Testing
- `dotnet test WebAdminPanel/ASL.LivingGrid.WebAdminPanel.Tests/ASL.LivingGrid.WebAdminPanel.Tests.csproj --no-build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684fb975f0348332b9ce78972243b356