### PR TITLE
Add build/test/deploy scripts and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,15 +77,35 @@ export DOTNET_ROOT="$HOME/.dotnet"
 export PATH="$PATH:$DOTNET_ROOT"
 ```
 
-### 4. Build
+### 4. Build & Test
+
+Use the provided PowerShell script to restore packages, build the solution and
+run all tests:
+
+```powershell
+pwsh ./Scripts/build.ps1
+```
+
+You can also execute the commands manually:
 
 ```bash
 dotnet build ASL.LivingGrid.sln
+dotnet test ASL.LivingGrid.sln --no-build
 ```
 
 ### 5. Run
 
-Each module can be run independently from its own solution.
+Each module can be run independently from its own solution using `dotnet run`.
+
+### 6. Deployment
+
+Publish release binaries with the deploy script:
+
+```bash
+bash ./Scripts/deploy.sh [Release|Debug]
+```
+
+Artifacts are placed in the `publish/` directory.
 
 ## Development Workflow
 

--- a/Scripts/README.md
+++ b/Scripts/README.md
@@ -1,2 +1,14 @@
 # Scripts
-Build and deployment scripts.
+
+Utility scripts to build, test and deploy the solution.
+
+- **build.ps1** – PowerShell script that restores packages, builds all projects and runs the unit tests. Usage:
+  ```powershell
+  pwsh ./Scripts/build.ps1 [Release|Debug]
+  ```
+- **deploy.sh** – Bash script that publishes the solution to a `publish` folder. Usage:
+  ```bash
+  bash ./Scripts/deploy.sh [Release|Debug]
+  ```
+
+Both scripts expect .NET 9 SDK to be installed and should be executed from the repository root or `Scripts` directory.

--- a/Scripts/build.ps1
+++ b/Scripts/build.ps1
@@ -1,0 +1,12 @@
+param(
+    [string]$Configuration = "Release"
+)
+
+Write-Host "Restoring packages..."
+dotnet restore ..\ASL.LivingGrid.sln
+
+Write-Host "Building solution..."
+dotnet build ..\ASL.LivingGrid.sln -c $Configuration
+
+Write-Host "Running tests..."
+dotnet test ..\ASL.LivingGrid.sln -c $Configuration --no-build

--- a/Scripts/deploy.sh
+++ b/Scripts/deploy.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+
+CONFIGURATION=${1:-Release}
+PUBLISH_DIR="../publish"
+
+echo "Publishing solution in $CONFIGURATION configuration..."
+dotnet publish ../ASL.LivingGrid.sln -c $CONFIGURATION -o "$PUBLISH_DIR"
+
+echo "Output located at $PUBLISH_DIR"


### PR DESCRIPTION
## Summary
- document how to build, test and deploy the solution
- add build.ps1 PowerShell script and deploy.sh script
- update Scripts README with usage examples

## Testing
- `dotnet build ASL.LivingGrid.sln` *(fails: command not found)*
- `bash Scripts/deploy.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fb97a0fe48332b8da62350a3242e6