### PR TITLE
Dynamic year in login layout

### DIFF
--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Components/Layout/LoginLayout.razor
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Components/Layout/LoginLayout.razor
@@ -14,7 +14,7 @@
         </div>
         
         <div class="login-footer">
-            <p>Copyright (c) 2025 Vusal Azer oglu Mastaliyev</p>
+            <p>@($"Copyright (c) {DateTime.Now.Year} Vusal Azer oglu Mastaliyev")</p>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- make LoginLayout footer show current year

## Testing
- `dotnet build ASL.LivingGrid.sln` *(fails: `dotnet` not found)*


------
https://chatgpt.com/codex/tasks/task_e_684fb98348388332a15f885bc1f2cbf1