### PR TITLE
Make build and deploy scripts location aware

### DIFF
--- a/Scripts/README.md
+++ b/Scripts/README.md
@@ -11,4 +11,5 @@ Utility scripts to build, test and deploy the solution.
   bash ./Scripts/deploy.sh [Release|Debug]
   ```
 
-Both scripts expect .NET 9 SDK to be installed and should be executed from the repository root or `Scripts` directory.
+Both scripts expect .NET 9 SDK to be installed. They automatically detect their
+own location, so you can run them from any directory.

--- a/Scripts/build.ps1
+++ b/Scripts/build.ps1
@@ -2,11 +2,17 @@ param(
     [string]$Configuration = "Release"
 )
 
+# Determine the directory of this script so the script can be executed
+# from any location. `$PSScriptRoot` points to the folder containing the
+# current PowerShell script.
+$scriptDir = $PSScriptRoot
+$solutionPath = Join-Path (Join-Path $scriptDir "..") "ASL.LivingGrid.sln"
+
 Write-Host "Restoring packages..."
-dotnet restore ..\ASL.LivingGrid.sln
+dotnet restore $solutionPath
 
 Write-Host "Building solution..."
-dotnet build ..\ASL.LivingGrid.sln -c $Configuration
+dotnet build $solutionPath -c $Configuration
 
 Write-Host "Running tests..."
-dotnet test ..\ASL.LivingGrid.sln -c $Configuration --no-build
+dotnet test $solutionPath -c $Configuration --no-build

--- a/Scripts/deploy.sh
+++ b/Scripts/deploy.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
 set -e
 
+# Determine the directory of this script so the script can be executed from
+# any location. `dirname "$0"` returns the folder containing this script.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 CONFIGURATION=${1:-Release}
-PUBLISH_DIR="../publish"
+PUBLISH_DIR="$SCRIPT_DIR/../publish"
+SOLUTION="$SCRIPT_DIR/../ASL.LivingGrid.sln"
 
 echo "Publishing solution in $CONFIGURATION configuration..."
-dotnet publish ../ASL.LivingGrid.sln -c $CONFIGURATION -o "$PUBLISH_DIR"
+dotnet publish "$SOLUTION" -c "$CONFIGURATION" -o "$PUBLISH_DIR"
 
 echo "Output located at $PUBLISH_DIR"


### PR DESCRIPTION
## Summary
- make `build.ps1` use `$PSScriptRoot` to locate solution
- make `deploy.sh` use its directory to find the solution and publish directory
- update README instructions about script execution

## Testing
- `pwsh ./Scripts/build.ps1` *(fails: `pwsh` not found)*


------
https://chatgpt.com/codex/tasks/task_e_684fbbf060688332aa257d2f736bd4b3