### PR TITLE
Add tests for widget services

### DIFF
--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel.Tests/Services/WidgetMarketplaceServiceTests.cs
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel.Tests/Services/WidgetMarketplaceServiceTests.cs
@@ -1,0 +1,124 @@
+using System.Net;
+using System.Net.Http;
+using ASL.LivingGrid.WebAdminPanel.Models;
+using ASL.LivingGrid.WebAdminPanel.Services;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace ASL.LivingGrid.WebAdminPanel.Tests.Services;
+
+public class WidgetMarketplaceServiceTests
+{
+    [Fact]
+    public async Task ListAsync_ReadsFromLocalFile()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+        var jsonFile = Path.Combine(tempDir, "widget_marketplace.json");
+        var json = "[{\"Id\":\"w1\",\"Name\":\"Widget\",\"Description\":\"Desc\",\"DownloadUrl\":\"http://example.com/widget.json\",\"PreviewImage\":\"img\"}]";
+        await File.WriteAllTextAsync(jsonFile, json);
+
+        var envMock = new Mock<IWebHostEnvironment>();
+        envMock.SetupGet(e => e.ContentRootPath).Returns(tempDir);
+        envMock.SetupGet(e => e.WebRootPath).Returns(tempDir);
+        var factoryMock = new Mock<IHttpClientFactory>();
+        var loggerMock = new Mock<ILogger<WidgetMarketplaceService>>();
+        var configuration = new ConfigurationBuilder().Build();
+        var service = new WidgetMarketplaceService(envMock.Object, factoryMock.Object, loggerMock.Object, configuration);
+
+        var widgets = await service.ListAsync();
+        var widget = Assert.Single(widgets);
+        Assert.Equal("w1", widget.Id);
+    }
+
+    [Fact]
+    public async Task ListAsync_LoadsFromUrl()
+    {
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("[{\\"Id\\":\\"w1\\",\\"Name\\":\\"Widget\\",\\"Description\\":\\"Desc\\",\\"DownloadUrl\\":\\"http://example.com/widget.json\\",\\"PreviewImage\\":\\"img\\"}]")
+            });
+        var httpClient = new HttpClient(handlerMock.Object);
+        var factoryMock = new Mock<IHttpClientFactory>();
+        factoryMock.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(httpClient);
+
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+        var envMock = new Mock<IWebHostEnvironment>();
+        envMock.SetupGet(e => e.ContentRootPath).Returns(tempDir);
+        envMock.SetupGet(e => e.WebRootPath).Returns(tempDir);
+        var loggerMock = new Mock<ILogger<WidgetMarketplaceService>>();
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["WidgetMarketplace:Source"] = "http://example.com/marketplace.json"
+        }).Build();
+        var service = new WidgetMarketplaceService(envMock.Object, factoryMock.Object, loggerMock.Object, configuration);
+
+        var widgets = await service.ListAsync();
+        var widget = Assert.Single(widgets);
+        Assert.Equal("w1", widget.Id);
+    }
+
+    [Fact]
+    public async Task ImportAsync_DownloadsAndSavesFile()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(Path.Combine(tempDir, "www", "widgets"));
+        var jsonFile = Path.Combine(tempDir, "widget_marketplace.json");
+        var marketplaceJson = "[{\"Id\":\"w1\",\"Name\":\"Widget\",\"Description\":\"Desc\",\"DownloadUrl\":\"http://example.com/widget.json\",\"PreviewImage\":\"img\"}]";
+        await File.WriteAllTextAsync(jsonFile, marketplaceJson);
+
+        var widgetJson = "{\"Id\":\"w1\"}";
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(widgetJson)
+            });
+        var httpClient = new HttpClient(handlerMock.Object);
+        var factoryMock = new Mock<IHttpClientFactory>();
+        factoryMock.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(httpClient);
+
+        var envMock = new Mock<IWebHostEnvironment>();
+        envMock.SetupGet(e => e.ContentRootPath).Returns(tempDir);
+        envMock.SetupGet(e => e.WebRootPath).Returns(Path.Combine(tempDir, "www"));
+        var loggerMock = new Mock<ILogger<WidgetMarketplaceService>>();
+        var configuration = new ConfigurationBuilder().Build();
+        var service = new WidgetMarketplaceService(envMock.Object, factoryMock.Object, loggerMock.Object, configuration);
+
+        var result = await service.ImportAsync("w1");
+        Assert.NotNull(result);
+        var expectedFile = Path.Combine(tempDir, "www", "widgets", "w1.json");
+        Assert.True(File.Exists(expectedFile));
+    }
+
+    [Fact]
+    public async Task ExportAsync_ReadsFile()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        var widgetsDir = Path.Combine(tempDir, "widgets");
+        Directory.CreateDirectory(widgetsDir);
+        var file = Path.Combine(widgetsDir, "w1.json");
+        await File.WriteAllTextAsync(file, "content");
+
+        var envMock = new Mock<IWebHostEnvironment>();
+        envMock.SetupGet(e => e.WebRootPath).Returns(tempDir);
+        envMock.SetupGet(e => e.ContentRootPath).Returns(tempDir);
+        var factoryMock = new Mock<IHttpClientFactory>();
+        var loggerMock = new Mock<ILogger<WidgetMarketplaceService>>();
+        var configuration = new ConfigurationBuilder().Build();
+        var service = new WidgetMarketplaceService(envMock.Object, factoryMock.Object, loggerMock.Object, configuration);
+
+        var result = await service.ExportAsync("w1");
+        Assert.Equal("content", result);
+    }
+}
+

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel.Tests/Services/WidgetPermissionServiceTests.cs
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel.Tests/Services/WidgetPermissionServiceTests.cs
@@ -1,0 +1,80 @@
+using System.Security.Claims;
+using ASL.LivingGrid.WebAdminPanel.Models;
+using ASL.LivingGrid.WebAdminPanel.Services;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace ASL.LivingGrid.WebAdminPanel.Tests.Services;
+
+public class WidgetPermissionServiceTests
+{
+    private static (WidgetPermissionService, string) CreateService(string json)
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+        File.WriteAllText(Path.Combine(tempDir, "widget_permissions.json"), json);
+        var envMock = new Mock<IWebHostEnvironment>();
+        envMock.SetupGet(e => e.ContentRootPath).Returns(tempDir);
+        var loggerMock = new Mock<ILogger<WidgetPermissionService>>();
+        var service = new WidgetPermissionService(envMock.Object, loggerMock.Object);
+        return (service, tempDir);
+    }
+
+    private static ClaimsPrincipal CreateUser(string id)
+    {
+        var identity = new ClaimsIdentity(new[] { new Claim(ClaimTypes.NameIdentifier, id) });
+        return new ClaimsPrincipal(identity);
+    }
+
+    [Fact]
+    public void HasAccess_DeniesByModule()
+    {
+        var json = "{\"w1\":{\"Modules\":[\"m1\"]}}";
+        var (service, _) = CreateService(json);
+        var user = CreateUser("u1");
+        var result = service.HasAccess("w1", user, module: "m2");
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void HasAccess_DeniesByTenant()
+    {
+        var json = "{\"w1\":{\"Tenants\":[\"t1\"]}}";
+        var (service, _) = CreateService(json);
+        var user = CreateUser("u1");
+        var result = service.HasAccess("w1", user, tenantId: "t2");
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void HasAccess_DeniesByUser()
+    {
+        var json = "{\"w1\":{\"Users\":[\"u1\"]}}";
+        var (service, _) = CreateService(json);
+        var user = CreateUser("u2");
+        var result = service.HasAccess("w1", user);
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void HasAccess_AllowsWhenNoEntry()
+    {
+        var (service, _) = CreateService("{}");
+        var user = CreateUser("u1");
+        var result = service.HasAccess("w1", user);
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void HasAccess_AllowsWhenMatches()
+    {
+        var json = "{\"w1\":{\"Modules\":[\"m1\"],\"Tenants\":[\"t1\"],\"Users\":[\"u1\"]}}";
+        var (service, _) = CreateService(json);
+        var user = CreateUser("u1");
+        var result = service.HasAccess("w1", user, "t1", "m1");
+        Assert.True(result);
+    }
+}
+

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel.Tests/Services/WidgetServiceTests.cs
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel.Tests/Services/WidgetServiceTests.cs
@@ -1,0 +1,73 @@
+using System.Security.Claims;
+using ASL.LivingGrid.WebAdminPanel.Models;
+using ASL.LivingGrid.WebAdminPanel.Services;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.JSInterop;
+using Moq;
+using Xunit;
+
+namespace ASL.LivingGrid.WebAdminPanel.Tests.Services;
+
+public class WidgetServiceTests
+{
+    [Fact]
+    public async Task InstallAndRemoveWidget_PersistsChanges()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+        var envMock = new Mock<IWebHostEnvironment>();
+        envMock.SetupGet(e => e.ContentRootPath).Returns(tempDir);
+        var jsMock = new Mock<IJSRuntime>();
+        var loggerMock = new Mock<ILogger<WidgetService>>();
+        var service = new WidgetService(envMock.Object, jsMock.Object, loggerMock.Object);
+
+        var widget = new WidgetDefinition { Id = "w1", Name = "Widget" };
+        await service.InstallWidgetAsync(widget);
+        var installed = await service.GetInstalledWidgetsAsync();
+        Assert.Single(installed);
+
+        await service.RemoveWidgetAsync("w1");
+        installed = await service.GetInstalledWidgetsAsync();
+        Assert.Empty(installed);
+    }
+
+    [Fact]
+    public async Task GetAndSaveUserWidgets_UsesJsRuntime()
+    {
+        var envMock = new Mock<IWebHostEnvironment>();
+        envMock.SetupGet(e => e.ContentRootPath).Returns(Path.GetTempPath());
+        var jsMock = new Mock<IJSRuntime>();
+        jsMock.Setup(j => j.InvokeAsync<string?>("aslWidgets.getWidgets", It.IsAny<object?[]>()))
+            .ReturnsAsync("[\"w1\"]");
+        var loggerMock = new Mock<ILogger<WidgetService>>();
+        var service = new WidgetService(envMock.Object, jsMock.Object, loggerMock.Object);
+
+        var widgets = await service.GetUserWidgetsAsync("c", "u");
+        Assert.Single(widgets);
+        Assert.Equal("w1", widgets[0]);
+
+        await service.SaveUserWidgetsAsync("c", "u", new List<string> { "w1", "w2" });
+        jsMock.Verify(j => j.InvokeVoidAsync("aslWidgets.saveWidgets", It.Is<object[]>(o =>
+            o[0]!.Equals("c") && o[1]!.Equals("u") && o[2]!.ToString()!.Contains("w2"))), Times.Once);
+    }
+
+    [Fact]
+    public async Task UsageTracking_CallsJsRuntime()
+    {
+        var envMock = new Mock<IWebHostEnvironment>();
+        envMock.SetupGet(e => e.ContentRootPath).Returns(Path.GetTempPath());
+        var jsMock = new Mock<IJSRuntime>();
+        jsMock.Setup(j => j.InvokeAsync<int>("aslWidgets.getUsage", It.IsAny<object?[]>()))
+            .ReturnsAsync(3);
+        var loggerMock = new Mock<ILogger<WidgetService>>();
+        var service = new WidgetService(envMock.Object, jsMock.Object, loggerMock.Object);
+
+        await service.IncrementUsageAsync("w1");
+        jsMock.Verify(j => j.InvokeVoidAsync("aslWidgets.incrementUsage", It.Is<object[]>(o => o[0]!.Equals("w1"))), Times.Once);
+
+        var usage = await service.GetUsageAsync("w1");
+        Assert.Equal(3, usage);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add WidgetService tests
- add WidgetPermissionService tests
- add WidgetMarketplaceService tests

## Testing
- `dotnet test ASL.LivingGrid.sln --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fc239a29483328b5c8dc66c17ec53