### PR TITLE
Add Slack notification channel and notifications center

### DIFF
--- a/For Developer/NotificationBook/README.md
+++ b/For Developer/NotificationBook/README.md
@@ -1,0 +1,27 @@
+# NotificationBook
+
+Bu sənəd WebAdminPanel modulunda bildiriş mərkəzinin və Slack kanalının istifadəsini izah edir.
+
+## Qısa xülasə
+Bildiriş xidməti müxtəlif kanallar vasitəsilə məlumat göndərməyə imkan verir. Yeni **SlackNotificationChannel** `Notifications:SlackWebhookUrl` ünvanına POST sorğusu edərək mesajları Slack-də göstərir.
+
+## Niyə yaradılıb?
+- İstifadəçiləri operativ şəkildə xəbərlərdən xəbərdar etmək.
+- Slack kimi məşhur əməkdaşlıq platformasına inteqrasiyanı asanlaşdırmaq.
+
+## Nəyə xidmət edir?
+- E-poçt, SMS, Telegram və Webhook kanallarına əlavə olaraq Slack üzərindən də bildiriş göndərməyə.
+- `/notifications-center` səhifəsində istifadəçi üçün toplanmış bildirişləri oxumağa və idarə etməyə.
+
+## İstifadə qaydası və idarəetmə prinsipləri
+1. `appsettings.json` faylında `Notifications:EnableSlackNotifications` dəyərini `true` edin və `Notifications:SlackWebhookUrl` sahəsinə Slack webhook ünvanını yazın.
+2. Sistem daxilində bildiriş yaradıldıqda `SlackNotificationChannel` avtomatik həmin webhook-a mesaj göndərəcək.
+3. İstifadəçi menyusundan **Bildiriş Mərkəzi** bölməsinə daxil olaraq bütün bildirişləri görə və "Read" düyməsi ilə oxundu kimi işarələyə bilər.
+
+## Texniki və biznes üstünlükləri
+- Komandadaxili operativlik artır, çünki kritik məlumatlar Slack kanallarında dərhal görünür.
+- Sadə konfiqurasiya ilə istənilən şirkət və tenant üçün aktivləşdirilə bilər.
+
+## Gələcək inkişaf yolları və risklər
+- Mesaj formatının zənginləşdirilməsi (emoji, bloklar, linklər).
+- Webhook ünvanının yanlış qurulması mesajların itməsi riskini yaradır.

--- a/Frontend_TODO.md
+++ b/Frontend_TODO.md
@@ -245,7 +245,7 @@ Bu modulda və ya alt modulda hər bir yeni funksiya, əlavə, düzəliş və ya
 - [x] Advanced filters, custom BI reporting
 - [x] Export (PDF, Excel, CSV, JSON, Parquet)
 - [x] Visual audit timeline, full audit event export (SIEM/Splunk/Syslog)
-- [ ] Built-in notification center, alert templates, integrations (Email, Telegram, Slack)
+ - [x] Built-in notification center, alert templates, integrations (Email, Telegram, Slack)
 - [x] **Audit log export/import, external SIEM/Syslog integration**
 - [ ] **Custom report designer, query builder, scheduled report delivery**
 - [x] **Per-role/tenant reporting permissions**

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Components/Layout/NavMenu.razor
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Components/Layout/NavMenu.razor
@@ -85,6 +85,7 @@
             localizedStrings["Navigation.WidgetMarketplace"] = "Widget Bazarı";
             localizedStrings["Navigation.DashboardDesigner"] = "Panel Dizayneri";
             localizedStrings["Navigation.PermissionMatrix"] = "İcazə Matrisi";
+            localizedStrings["Navigation.NotificationsCenter"] = "Bildiriş Mərkəzi";
         }
 
         var authState = await AuthProvider.GetAuthenticationStateAsync();

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Components/Pages/NotificationsCenter.razor
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Components/Pages/NotificationsCenter.razor
@@ -1,0 +1,75 @@
+@page "/notifications-center"
+@using System.Security.Claims
+@attribute [Authorize]
+@inject INotificationService NotificationService
+@inject AuthenticationStateProvider Auth
+
+<h3>Notifications Center</h3>
+
+@if (items is null)
+{
+    <p>Loading...</p>
+}
+else if (!items.Any())
+{
+    <p>No notifications.</p>
+}
+else
+{
+    <button class="btn btn-sm btn-secondary mb-2" @onclick="MarkAllRead">Mark All Read</button>
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th>Title</th>
+                <th>Message</th>
+                <th>Date</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var n in items)
+            {
+                <tr class="@(n.IsRead ? string.Empty : "table-warning")">
+                    <td>@n.Title</td>
+                    <td>@n.Message</td>
+                    <td>@n.CreatedAt.ToLocalTime().ToString("g")</td>
+                    <td>
+                        @if (!n.IsRead)
+                        {
+                            <button class="btn btn-sm btn-primary" @onclick="() => MarkRead(n.Id)">Read</button>
+                        }
+                    </td>
+                </tr>
+            }
+        </tbody>
+    </table>
+}
+
+@code {
+    private List<Notification>? items;
+    private string userId = string.Empty;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var state = await Auth.GetAuthenticationStateAsync();
+        userId = state.User.FindFirstValue(ClaimTypes.NameIdentifier) ?? string.Empty;
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        items = (await NotificationService.GetUserNotificationsAsync(userId, true, 0, 100)).ToList();
+    }
+
+    private async Task MarkRead(Guid id)
+    {
+        await NotificationService.MarkAsReadAsync(id, userId);
+        await LoadAsync();
+    }
+
+    private async Task MarkAllRead()
+    {
+        await NotificationService.MarkAllAsReadAsync(userId);
+        await LoadAsync();
+    }
+}

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Program.cs
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Program.cs
@@ -145,6 +145,7 @@ public class Program
         services.AddScoped<INotificationChannel, SmsNotificationChannel>();
         services.AddScoped<INotificationChannel, TelegramNotificationChannel>();
         services.AddScoped<INotificationChannel, WebhookNotificationChannel>();
+        services.AddScoped<INotificationChannel, SlackNotificationChannel>();
         services.AddScoped<IPluginService, PluginService>();
         services.AddScoped<IPluginMarketplaceService, PluginMarketplaceService>();
         services.AddScoped<ITranslationProviderService, TranslationProviderService>();

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Services/NavigationService.cs
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Services/NavigationService.cs
@@ -79,6 +79,7 @@ public class NavigationService : INavigationService
         new NavigationItem { Key = "Navigation.Audit", Url = "audit", Icon = "oi oi-clipboard" },
         new NavigationItem { Key = "Navigation.UIAudit", Url = "uiaudit", Icon = "oi oi-eye" },
         new NavigationItem { Key = "Navigation.Notifications", Url = "notifications", Icon = "oi oi-bell" },
+        new NavigationItem { Key = "Navigation.NotificationsCenter", Url = "notifications-center", Icon = "oi oi-bell" },
         new NavigationItem { Key = "Navigation.Plugins", Url = "plugins", Icon = "oi oi-puzzle-piece" }
     };
 }

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Services/SlackNotificationChannel.cs
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Services/SlackNotificationChannel.cs
@@ -1,0 +1,36 @@
+using ASL.LivingGrid.WebAdminPanel.Models;
+using System.Net.Http.Json;
+
+namespace ASL.LivingGrid.WebAdminPanel.Services;
+
+public class SlackNotificationChannel : INotificationChannel
+{
+    private readonly IConfiguration _config;
+    private readonly IHttpClientFactory _factory;
+    private readonly ILogger<SlackNotificationChannel> _logger;
+
+    public SlackNotificationChannel(IConfiguration config, IHttpClientFactory factory, ILogger<SlackNotificationChannel> logger)
+    {
+        _config = config;
+        _factory = factory;
+        _logger = logger;
+    }
+
+    public async Task SendAsync(Notification notification)
+    {
+        if (!_config.GetValue<bool>("Notifications:EnableSlackNotifications"))
+            return;
+        var url = _config["Notifications:SlackWebhookUrl"];
+        if (string.IsNullOrEmpty(url)) return;
+        try
+        {
+            var client = _factory.CreateClient();
+            var payload = new { text = $"{notification.Title}: {notification.Message}" };
+            await client.PostAsJsonAsync(url, payload);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Slack send failed");
+        }
+    }
+}

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/menuitems.json
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/menuitems.json
@@ -52,6 +52,11 @@
     "Icon": "oi oi-bell"
   },
   {
+    "Key": "Navigation.NotificationsCenter",
+    "Url": "notifications-center",
+    "Icon": "oi oi-bell"
+  },
+  {
     "Key": "Navigation.Plugins",
     "Url": "plugins",
     "Icon": "oi oi-puzzle-piece"


### PR DESCRIPTION
## Summary
- implement `SlackNotificationChannel`
- register channel in `Program.cs`
- add `/notifications-center` Razor page showing notifications
- update navigation menu items and localization
- add developer notes about notification usage
- mark notification center TODO item complete

## Testing
- `dotnet build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684fcb115af483329cbe69bc4f6693a1