### PR TITLE
Add Slack notification settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ To enforce HTTPS redirection when hosting the WebAdminPanel, set the
 variable). The previous `ForceHttps` key is still accepted for backwards
 compatibility but will be removed in future versions.
 
+Slack integration can be enabled by setting
+`Notifications:EnableSlackNotifications` to `true` and specifying the
+`Notifications:SlackWebhookUrl` in `appsettings.json`.
+
 ## Development Workflow
 
 Please read `Read before you start working.md` before beginning any development work. The project follows strict Core Rules and workflow guidelines with progress tracking through TODO.md files. Continuous integration runs via GitHub Actions using `.github/workflows/dotnet.yml`.

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/appsettings.json
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/appsettings.json
@@ -48,6 +48,10 @@
     "DefaultLanguage": "az",
     "SupportedLanguages": ["az", "en", "tr", "ru"]
   },
+  "Notifications": {
+    "EnableSlackNotifications": false,
+    "SlackWebhookUrl": ""
+  },
   "Translation": {
     "Provider": "OpenAI",
     "ApiKey": "",


### PR DESCRIPTION
## Summary
- add `Notifications` section with Slack options to appsettings.json
- document Slack config in README

## Testing
- `dotnet build ASL.LivingGrid.sln` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684fdd2f958083329d0f46c5c62a826e