### PR TITLE
Fix plugin removal with invalid GUID

### DIFF
--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel.Tests/Services/PluginServiceTests.cs
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel.Tests/Services/PluginServiceTests.cs
@@ -1,0 +1,36 @@
+using ASL.LivingGrid.WebAdminPanel.Models;
+using ASL.LivingGrid.WebAdminPanel.Services;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace ASL.LivingGrid.WebAdminPanel.Tests.Services;
+
+public class PluginServiceTests
+{
+    [Fact]
+    public async Task RemovePluginAsync_InvalidId_LogsError()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+        var envMock = new Mock<IWebHostEnvironment>();
+        envMock.SetupGet(e => e.ContentRootPath).Returns(tempDir);
+        var loggerMock = new Mock<ILogger<PluginService>>();
+        var service = new PluginService(envMock.Object, loggerMock.Object);
+
+        var plugin = new Plugin { Name = "Test", Version = "1.0" };
+        await service.InstallPluginAsync(plugin);
+
+        await service.RemovePluginAsync("not-a-guid");
+
+        var installed = await service.GetInstalledPluginsAsync();
+        Assert.Single(installed);
+        loggerMock.Verify(l => l.Log(
+            LogLevel.Error,
+            It.IsAny<EventId>(),
+            It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Invalid plugin id")),
+            It.IsAny<Exception?>(),
+            It.IsAny<Func<It.IsAnyType, Exception?, string>>()), Times.Once);
+    }
+}

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Services/PluginService.cs
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Services/PluginService.cs
@@ -63,7 +63,13 @@ public class PluginService : IPluginService
     public async Task RemovePluginAsync(string id)
     {
         await LoadAsync();
-        var p = _installed.FirstOrDefault(x => x.Id == Guid.Parse(id));
+        if (!Guid.TryParse(id, out var pluginId))
+        {
+            _logger.LogError("Invalid plugin id: {Id}", id);
+            return;
+        }
+
+        var p = _installed.FirstOrDefault(x => x.Id == pluginId);
         if (p != null)
         {
             _installed.Remove(p);


### PR DESCRIPTION
## Summary
- handle invalid plugin IDs safely with `Guid.TryParse`
- log and exit if GUID is invalid
- add PluginService unit test for invalid GUID removal

## Testing
- `dotnet test WebAdminPanel/WebAdminPanel.sln --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fe6ed9bdc8332be4af57ce3c79b89