### PR TITLE
Add localization update interval configuration

### DIFF
--- a/For Developer/LocalizationBook/README.md
+++ b/For Developer/LocalizationBook/README.md
@@ -109,6 +109,8 @@ POST /api/languagepacks/rate/{id}
 
 ## Yeniləmələr və Rollback
 `LocalizationUpdateService` fon xidməti `pending_languagepack_updates.json` faylını oxuyaraq yeni dil paketlərini mərhələli şəkildə tətbiq edir. Hər yeniləmə `AuditService` vasitəsilə jurnal olunur və `NotificationService` istifadəçilərə bildiriş göndərir. Faylda `Applied` sahəsi yenilənməmiş qeydləri işarələməyə imkan verir.
+Yeniləmə yoxlamalarının tezliyi `Localization:UpdateIntervalMinutes` parametrində
+dəqiqə olaraq təyin edilir və göstərilmədikdə 30 dəqiqə qəbul olunur.
 
 Rollback üçün əvvəlki dil paketlərini `Export` əməliyyatı ilə saxlayıb istənilən vaxt `Import` edə bilərsiniz.
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,11 @@ Slack integration can be enabled by setting
 `Notifications:EnableSlackNotifications` to `true` and specifying the
 `Notifications:SlackWebhookUrl` in `appsettings.json`.
 
+Localization update checks are controlled by
+`Localization:UpdateIntervalMinutes`. This sets how often the
+`LocalizationUpdateService` looks for new language packs (default: 30
+minutes).
+
 ## Development Workflow
 
 Please read `Read before you start working.md` before beginning any development work. The project follows strict Core Rules and workflow guidelines with progress tracking through TODO.md files. Continuous integration runs via GitHub Actions using `.github/workflows/dotnet.yml`.

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Services/LocalizationUpdateService.cs
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Services/LocalizationUpdateService.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Microsoft.Extensions.Hosting;
 using ASL.LivingGrid.WebAdminPanel.Models;
+using Microsoft.Extensions.Configuration;
 
 namespace ASL.LivingGrid.WebAdminPanel.Services;
 
@@ -9,13 +10,17 @@ public class LocalizationUpdateService : BackgroundService
     private readonly ILogger<LocalizationUpdateService> _logger;
     private readonly IServiceProvider _provider;
     private readonly IWebHostEnvironment _env;
-    private readonly TimeSpan _interval = TimeSpan.FromMinutes(30);
+    private readonly TimeSpan _interval;
+    private readonly IConfiguration _configuration;
 
-    public LocalizationUpdateService(ILogger<LocalizationUpdateService> logger, IServiceProvider provider, IWebHostEnvironment env)
+    public LocalizationUpdateService(ILogger<LocalizationUpdateService> logger, IServiceProvider provider, IWebHostEnvironment env, IConfiguration configuration)
     {
         _logger = logger;
         _provider = provider;
         _env = env;
+        _configuration = configuration;
+        var minutes = _configuration.GetValue<int>("Localization:UpdateIntervalMinutes", 30);
+        _interval = TimeSpan.FromMinutes(minutes);
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/appsettings.json
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/appsettings.json
@@ -60,5 +60,8 @@
     "Region": "",
     "RateLimitDelaySeconds": 0
   },
+  "Localization": {
+    "UpdateIntervalMinutes": 30
+  },
   "BackupDirectory": "backups"
 }


### PR DESCRIPTION
## Summary
- configure Localization:UpdateIntervalMinutes in appsettings.json
- read interval value in `LocalizationUpdateService`
- document the new setting in README and LocalizationBook

## Testing
- `dotnet build ASL.LivingGrid.sln` *(fails: command not found)*
- `dotnet test ASL.LivingGrid.sln --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684feb7521588332958c072e5747d195