### PR TITLE
Fix async directory copy recursion

### DIFF
--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Services/AdvancedRollbackService.cs
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Services/AdvancedRollbackService.cs
@@ -1519,25 +1519,22 @@ public class AdvancedRollbackService : IAdvancedRollbackService
 
     private async Task CopyDirectoryAsync(string sourceDir, string targetDir)
     {
-        await Task.Run(() =>
+        if (!Directory.Exists(sourceDir))
+            return;
+
+        Directory.CreateDirectory(targetDir);
+
+        foreach (var file in Directory.GetFiles(sourceDir))
         {
-            if (!Directory.Exists(sourceDir))
-                return;
+            var targetFile = Path.Combine(targetDir, Path.GetFileName(file));
+            File.Copy(file, targetFile, true);
+        }
 
-            Directory.CreateDirectory(targetDir);
-
-            foreach (var file in Directory.GetFiles(sourceDir))
-            {
-                var targetFile = Path.Combine(targetDir, Path.GetFileName(file));
-                File.Copy(file, targetFile, true);
-            }
-
-            foreach (var dir in Directory.GetDirectories(sourceDir))
-            {
-                var targetSubDir = Path.Combine(targetDir, Path.GetFileName(dir));
-                CopyDirectoryAsync(dir, targetSubDir).Wait();
-            }
-        });
+        foreach (var dir in Directory.GetDirectories(sourceDir))
+        {
+            var targetSubDir = Path.Combine(targetDir, Path.GetFileName(dir));
+            await CopyDirectoryAsync(dir, targetSubDir);
+        }
     }
 
     private long GetDirectorySize(string dirPath)

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Services/EnvironmentProvisioningService.cs
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Services/EnvironmentProvisioningService.cs
@@ -902,21 +902,21 @@ public class EnvironmentProvisioningService : IEnvironmentProvisioningService
 
     private async Task CopyDirectoryAsync(string sourcePath, string targetPath)
     {
-        await Task.Run(() =>
+        if (!Directory.Exists(sourcePath))
+            return;
+
+        Directory.CreateDirectory(targetPath);
+
+        foreach (var file in Directory.GetFiles(sourcePath))
         {
-            Directory.CreateDirectory(targetPath);
+            var targetFile = Path.Combine(targetPath, Path.GetFileName(file));
+            File.Copy(file, targetFile, true);
+        }
 
-            foreach (var file in Directory.GetFiles(sourcePath))
-            {
-                var targetFile = Path.Combine(targetPath, Path.GetFileName(file));
-                File.Copy(file, targetFile, true);
-            }
-
-            foreach (var dir in Directory.GetDirectories(sourcePath))
-            {
-                var targetDir = Path.Combine(targetPath, Path.GetFileName(dir));
-                CopyDirectoryAsync(dir, targetDir).Wait();
-            }
-        });
+        foreach (var dir in Directory.GetDirectories(sourcePath))
+        {
+            var targetDir = Path.Combine(targetPath, Path.GetFileName(dir));
+            await CopyDirectoryAsync(dir, targetDir);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- replace blocking `.Wait()` recursion with asynchronous `await` in `EnvironmentProvisioningService` and `AdvancedRollbackService`

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fef49b63083329e49717f36934b8f