### PR TITLE
Secure preview links

### DIFF
--- a/For Developer/SecurityBook/README.md
+++ b/For Developer/SecurityBook/README.md
@@ -34,4 +34,5 @@ Sistemin təhlükəsizliyini mərkəzləşdirilmiş şəkildə tənzimləmək v�
 3. **Tenant üzrə siyasət** – `Security:EnforcePerTenantPolicy` açarı aktiv olduqda hər tenant üçün `Security:Policy:{tenantId}` konfiqurasiyası tətbiq edilir.
 4. **Xarici identifikasiya provayderləri** – `Security:Oidc:*`, `Security:OAuth2:*`, `Security:Saml:*` və `Security:Ldap:*` parametrlərini dolduraraq qoşun.
 5. **Parol vaxtı və rotasiyası** – `Security:PasswordExpiryDays` dəyəri bitdikdə istifadəçi kilidlənir, yeni parol tələb olunur.
+6. **Wireframe önizləmə tokeni** – `Security:PreviewSecret` dəyəri ilə imzalanmış `token` parametri olmadan `/wireframes/preview/{id}` ünvanına giriş verilmir.
 

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Services/IWireframePageBuilderService.cs
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Services/IWireframePageBuilderService.cs
@@ -35,6 +35,7 @@ public interface IWireframePageBuilderService
     
     Task<WireframePreview> GeneratePreviewAsync(string pageId, PreviewMode mode);
     Task<bool> PublishPageAsync(string pageId, PublishOptions options);
+    string GetPreviewToken(string pageId, string? password = null);
 }
 
 public class WireframeProject

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/appsettings.json
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/appsettings.json
@@ -38,7 +38,8 @@
     "Cookie": {
       "SecurePolicy": "SameAsRequest",
       "SameSite": "Lax"
-    }
+    },
+    "PreviewSecret": "ChangeThisSecret"
   },
   "Features": {
     "EnableMultiLanguage": true,


### PR DESCRIPTION
## Summary
- add `PreviewSecret` configuration
- secure wireframe preview endpoint with token and add minimal API to serve previews
- remove prompt-based password protection and expose `GetPreviewToken`
- document new preview token setting

## Testing
- `dotnet test` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68500274d8d48332ac2fa882f2d0aaa3