### PR TITLE
Fix configuration header numbering

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ bash ./Scripts/deploy.sh [Release|Debug]
 
 Artifacts are placed in the `publish/` directory.
 
-### 6. Configuration
+### 7. Configuration
 
 To enforce HTTPS redirection when hosting the WebAdminPanel, set the
 `Security:RequireHttps` key in `appsettings.json` (or as an environment


### PR DESCRIPTION
## Summary
- update README configuration section heading

## Testing
- `pwsh ./Scripts/build.ps1` *(fails: command not found)*
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685008bd2f7c8332b4ed68f48aa22421