### PR TITLE
Use env vars for default admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,11 @@ Localization update checks are controlled by
 `LocalizationUpdateService` looks for new language packs (default: 30
 minutes).
 
+To automatically create a default administrator account in the WebAdminPanel,
+set the `DEFAULT_ADMIN_EMAIL` and `DEFAULT_ADMIN_PASSWORD` environment variables
+before first launch. If these variables are not defined, no admin user is
+created.
+
 ## Development Workflow
 
 Please read `Read before you start working.md` before beginning any development work. The project follows strict Core Rules and workflow guidelines with progress tracking through TODO.md files. Continuous integration runs via GitHub Actions using `.github/workflows/dotnet.yml`.

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Components/Login.razor
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Components/Login.razor
@@ -5,7 +5,6 @@
 @inject UserManager<IdentityUser> UserManager
 @inject NavigationManager Navigation
 @inject IJSRuntime JSRuntime
-@inject IConfiguration Configuration
 
 <div class="login-form">
     <EditForm Model="loginModel" OnValidSubmit="HandleLoginAsync" FormName="login">
@@ -99,8 +98,8 @@
     {
         try
         {
-            var email = Environment.GetEnvironmentVariable("DEFAULT_ADMIN_EMAIL") ?? Configuration["DefaultAdmin:Email"];
-            var password = Environment.GetEnvironmentVariable("DEFAULT_ADMIN_PASSWORD") ?? Configuration["DefaultAdmin:Password"];
+            var email = Environment.GetEnvironmentVariable("DEFAULT_ADMIN_EMAIL");
+            var password = Environment.GetEnvironmentVariable("DEFAULT_ADMIN_PASSWORD");
 
             if (string.IsNullOrWhiteSpace(email) || string.IsNullOrWhiteSpace(password))
                 return;

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/appsettings.json
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/appsettings.json
@@ -64,9 +64,5 @@
   "Localization": {
     "UpdateIntervalMinutes": 30
   },
-  "BackupDirectory": "backups",
-  "DefaultAdmin": {
-    "Email": "admin@asl.az",
-    "Password": "admin123"
-  }
+  "BackupDirectory": "backups"
 }


### PR DESCRIPTION
## Summary
- remove hard-coded DefaultAdmin section
- create default admin user only when DEFAULT_ADMIN_EMAIL and DEFAULT_ADMIN_PASSWORD are set
- document how to provide default admin credentials via environment variables

## Testing
- `dotnet build ASL.LivingGrid.sln` *(fails: package downgrade)*
- `dotnet test ASL.LivingGrid.sln --no-build` *(fails: invalid argument)*

------
https://chatgpt.com/codex/tasks/task_e_68500acfcbb8833288168490454e90dc