### PR TITLE
Async preview secret loading

### DIFF
--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Program.cs
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Program.cs
@@ -241,7 +241,7 @@ public class Program
             var token = ctx.Request.Query["token"].ToString();
             if (!(ctx.User?.Identity?.IsAuthenticated ?? false))
             {
-                if (token != svc.GetPreviewToken(pageId))
+                if (token != await svc.GetPreviewTokenAsync(pageId))
                     return Results.Unauthorized();
             }
 

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Services/IWireframePageBuilderService.cs
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Services/IWireframePageBuilderService.cs
@@ -35,7 +35,7 @@ public interface IWireframePageBuilderService
     
     Task<WireframePreview> GeneratePreviewAsync(string pageId, PreviewMode mode);
     Task<bool> PublishPageAsync(string pageId, PublishOptions options);
-    string GetPreviewToken(string pageId, string? password = null);
+    Task<string> GetPreviewTokenAsync(string pageId, string? password = null);
 }
 
 public class WireframeProject


### PR DESCRIPTION
## Summary
- lazy-load preview secret for WireframePageBuilderService
- make GetPreviewToken async to avoid blocking
- adjust Program.cs to use async token check

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850338488d48332808acb0572b22a3b