### PR TITLE
Enforce PreviewSecret configuration

### DIFF
--- a/For Developer/SecurityBook/README.md
+++ b/For Developer/SecurityBook/README.md
@@ -34,5 +34,6 @@ Sistemin təhlükəsizliyini mərkəzləşdirilmiş şəkildə tənzimləmək v�
 3. **Tenant üzrə siyasət** – `Security:EnforcePerTenantPolicy` açarı aktiv olduqda hər tenant üçün `Security:Policy:{tenantId}` konfiqurasiyası tətbiq edilir.
 4. **Xarici identifikasiya provayderləri** – `Security:Oidc:*`, `Security:OAuth2:*`, `Security:Saml:*` və `Security:Ldap:*` parametrlərini dolduraraq qoşun.
 5. **Parol vaxtı və rotasiyası** – `Security:PasswordExpiryDays` dəyəri bitdikdə istifadəçi kilidlənir, yeni parol tələb olunur.
-6. **Wireframe önizləmə tokeni** – `Security:PreviewSecret` dəyəri ilə imzalanmış `token` parametri olmadan `/wireframes/preview/{id}` ünvanına giriş verilmir.
+6. **Wireframe önizləmə tokeni** – `Security:PreviewSecret` məcburi dəyərdir. Bu secret ilə imzalanmış `token` parametri olmadan `/wireframes/preview/{id}` ünvanına giriş verilmir.
+7. **Gizli açarın təyin olunması** – `Security:PreviewSecret` dəyərini `appsettings.json` faylında və ya `Security__PreviewSecret` mühit dəyişəni kimi təyin edin. Açarı repozitoriyada saxlamayın, `dotnet user-secrets` və ya TPM/HSM əsaslı `TpmHsmSecretStorageService` vasitəsilə qoruyun.
 

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Services/WireframePageBuilderService.cs
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Services/WireframePageBuilderService.cs
@@ -57,12 +57,20 @@ public class WireframePageBuilderService : IWireframePageBuilderService
     {
         try
         {
-            return await _configService.GetValueAsync("Security:PreviewSecret") ?? "ChangeThisSecret";
+            var envSecret = Environment.GetEnvironmentVariable("Security__PreviewSecret");
+            if (!string.IsNullOrWhiteSpace(envSecret))
+                return envSecret;
+
+            var secret = await _configService.GetValueAsync("Security:PreviewSecret");
+            if (string.IsNullOrWhiteSpace(secret))
+                throw new InvalidOperationException("Security:PreviewSecret must be configured via appsettings or environment variable.");
+
+            return secret;
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error loading preview secret");
-            return "ChangeThisSecret";
+            _logger.LogCritical(ex, "Failed to load preview secret");
+            throw;
         }
     }
 

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/appsettings.json
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/appsettings.json
@@ -39,7 +39,7 @@
       "SecurePolicy": "SameAsRequest",
       "SameSite": "Lax"
     },
-    "PreviewSecret": "ChangeThisSecret"
+    "PreviewSecret": ""
   },
   "Features": {
     "EnableMultiLanguage": true,


### PR DESCRIPTION
## Summary
- require preview secret from configuration or env
- document how to set `Security:PreviewSecret`

## Testing
- `dotnet build ASL.LivingGrid.sln` *(fails: command not found)*
- `dotnet test ASL.LivingGrid.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685034c03dec8332a315510e0147d3a2