### PR TITLE
Document preview secret env var

### DIFF
--- a/For Developer/SecurityBook/README.md
+++ b/For Developer/SecurityBook/README.md
@@ -35,5 +35,5 @@ Sistemin təhlükəsizliyini mərkəzləşdirilmiş şəkildə tənzimləmək v�
 4. **Xarici identifikasiya provayderləri** – `Security:Oidc:*`, `Security:OAuth2:*`, `Security:Saml:*` və `Security:Ldap:*` parametrlərini dolduraraq qoşun.
 5. **Parol vaxtı və rotasiyası** – `Security:PasswordExpiryDays` dəyəri bitdikdə istifadəçi kilidlənir, yeni parol tələb olunur.
 6. **Wireframe önizləmə tokeni** – `Security:PreviewSecret` məcburi dəyərdir. Bu secret ilə imzalanmış `token` parametri olmadan `/wireframes/preview/{id}` ünvanına giriş verilmir.
-7. **Gizli açarın təyin olunması** – `Security:PreviewSecret` dəyərini `appsettings.json` faylında və ya `Security__PreviewSecret` mühit dəyişəni kimi təyin edin. Açarı repozitoriyada saxlamayın, `dotnet user-secrets` və ya TPM/HSM əsaslı `TpmHsmSecretStorageService` vasitəsilə qoruyun.
+7. **Gizli açarın təyin olunması** – `Security:PreviewSecret` dəyərini `appsettings.json`-da saxlamayın. Açarı `Security__PreviewSecret` mühit dəyişəni və ya `dotnet user-secrets` vasitəsilə təyin edin. TPM/HSM əsaslı `TpmHsmSecretStorageService` ilə qorumağı unutmayın.
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ Slack integration can be enabled by setting
 `Notifications:EnableSlackNotifications` to `true` and specifying the
 `Notifications:SlackWebhookUrl` in `appsettings.json`.
 
+Wireframe previews are protected with a secret token. Set `Security__PreviewSecret`
+as an environment variable or user secret before launch; otherwise the
+application will fail to start.
+
 Localization update checks are controlled by
 `Localization:UpdateIntervalMinutes`. This sets how often the
 `LocalizationUpdateService` looks for new language packs (default: 30

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Program.cs
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Program.cs
@@ -39,6 +39,11 @@ public class Program
             if (Environment.GetCommandLineArgs().Contains("--hosted"))
                 cfgMode = "WebServer";
             var isStandaloneExe = string.Equals(cfgMode, "Standalone", StringComparison.OrdinalIgnoreCase);
+
+            var previewSecret = builder.Configuration["Security:PreviewSecret"];
+            if (string.IsNullOrWhiteSpace(previewSecret))
+                throw new InvalidOperationException(
+                    "Security__PreviewSecret environment variable or user secret must be provided for wireframe previews.");
             
             // Configure logging
             builder.Host.UseSerilog();

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/appsettings.json
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/appsettings.json
@@ -39,7 +39,7 @@
       "SecurePolicy": "SameAsRequest",
       "SameSite": "Lax"
     },
-    "PreviewSecret": ""
+    "PreviewSecret": "${PREVIEW_SECRET}"
   },
   "Features": {
     "EnableMultiLanguage": true,


### PR DESCRIPTION
## Summary
- use placeholder for the preview secret in `appsettings.json`
- fail fast if `Security__PreviewSecret` isn't provided during startup
- document the required environment variable in README and SecurityBook

## Testing
- `dotnet test --no-build` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_685041a707088332a25e498c1509a2f8