### PR TITLE
Display server uptime

### DIFF
--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Components/Pages/Home.razor
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Components/Pages/Home.razor
@@ -1,6 +1,7 @@
 @page "/"
 @using Microsoft.AspNetCore.Authorization
 @using ASL.LivingGrid.WebAdminPanel.Services
+@using ASL.LivingGrid.WebAdminPanel
 @attribute [Authorize]
 @inject IConfigurationService ConfigurationService
 @inject ILocalizationService LocalizationService
@@ -167,7 +168,7 @@
         systemInfo = new SystemInfo
         {
             Version = "1.0.0",
-            Uptime = DateTime.Now.ToString("dd days HH:mm"),
+            Uptime = GetUptimeString(),
             DatabaseType = "SQLite",
             Environment = "Development"
         };
@@ -187,6 +188,12 @@
         {
             await JS.InvokeVoidAsync("toast.show", localizedStrings["Common.Welcome"]);
         }
+    }
+
+    private string GetUptimeString()
+    {
+        var uptime = DateTime.Now - Program.StartTime;
+        return $"{uptime.Days}d {uptime.Hours}h {uptime.Minutes}m";
     }
 
     public class SystemStats

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Program.cs
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Program.cs
@@ -11,12 +11,14 @@ using Microsoft.AspNetCore.HttpOverrides;
 using System.IO;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
+using System.Diagnostics;
 using Microsoft.AspNetCore.StaticFiles;
 
 namespace ASL.LivingGrid.WebAdminPanel;
 
 public class Program
 {
+    public static readonly DateTime StartTime = Process.GetCurrentProcess().StartTime;
     public static async Task Main(string[] args)
     {
         // Configure Serilog


### PR DESCRIPTION
## Summary
- track app start time in Program
- show formatted uptime on Home page

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68504a761a348332a6ab6f14ee01e295