### PR TITLE
Ensure PreviewSecret env var usage

### DIFF
--- a/For Developer/SecurityBook/README.md
+++ b/For Developer/SecurityBook/README.md
@@ -34,8 +34,14 @@ Sistemin təhlükəsizliyini mərkəzləşdirilmiş şəkildə tənzimləmək v�
 3. **Tenant üzrə siyasət** – `Security:EnforcePerTenantPolicy` açarı aktiv olduqda hər tenant üçün `Security:Policy:{tenantId}` konfiqurasiyası tətbiq edilir.
 4. **Xarici identifikasiya provayderləri** – `Security:Oidc:*`, `Security:OAuth2:*`, `Security:Saml:*` və `Security:Ldap:*` parametrlərini dolduraraq qoşun.
 5. **Parol vaxtı və rotasiyası** – `Security:PasswordExpiryDays` dəyəri bitdikdə istifadəçi kilidlənir, yeni parol tələb olunur.
-6. **Wireframe önizləmə tokeni** – `Security:PreviewSecret` məcburi dəyərdir. Bu secret ilə imzalanmış `token` parametri olmadan `/wireframes/preview/{id}` ünvanına giriş verilmir.
-7. **Gizli açarın təyin olunması** – `Security__PreviewSecret` mütləq mühit dəyişəni və ya `dotnet user-secrets` vasitəsilə təyin edilməlidir; boş və ya `${PREVIEW_SECRET}` kimi placeholder dəyərlər qəbul olunmur. Açarı `appsettings.json`-da saxlamaq təhlükəsizlik riskidir. TPM/HSM əsaslı `TpmHsmSecretStorageService` ilə qorumağı unutmayın.
+6. **Wireframe önizləmə tokeni** – `Security:PreviewSecret` məcburi dəyərdir. Bu
+   secret ilə imzalanmış `token` parametri olmadan `/wireframes/preview/{id}`
+   ünvanına giriş verilmir.
+7. **Gizli açarın təyin olunması** – `Security__PreviewSecret` mütləq mühit
+   dəyişəni və ya `dotnet user-secrets` vasitəsilə təyin edilməlidir. Dəyəri
+   `appsettings.json`-da saxlamayın; əks halda proqram başlamayacaq. Boş və ya
+   `${PREVIEW_SECRET}` kimi placeholder dəyərlər qəbul olunmur. Secret-i
+   TPM/HSM əsaslı `TpmHsmSecretStorageService` ilə qorumağı unutmayın.
 
 ### Default admin hesabının yaradılması
 `DEFAULT_ADMIN_EMAIL` və `DEFAULT_ADMIN_PASSWORD` dəyişənlərini təyin etdikdə, WebAdminPanel ilk başladıqda həmin məlumatlarla admin istifadəçi avtomatik yaradılır.

--- a/README.md
+++ b/README.md
@@ -142,9 +142,11 @@ Slack integration can be enabled by setting
 `Notifications:EnableSlackNotifications` to `true` and specifying the
 `Notifications:SlackWebhookUrl` in `appsettings.json`.
 
-Wireframe previews are protected with a secret token. Set `Security__PreviewSecret`
-as an environment variable or user secret before launch; otherwise the
-application will fail to start.
+Wireframe previews are protected with a secret token. Set
+`Security__PreviewSecret` via environment variable or the
+`dotnet user-secrets` tool before launch. **Do not place the value in
+`appsettings.json`.** Without this secret the application refuses to
+start.
 
 Localization update checks are controlled by
 `Localization:UpdateIntervalMinutes`. This sets how often the

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/appsettings.json
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/appsettings.json
@@ -39,7 +39,7 @@
       "SecurePolicy": "SameAsRequest",
       "SameSite": "Lax"
     },
-    "PreviewSecret": ""
+    "PreviewSecret": "${PREVIEW_SECRET}"
   },
   "Features": {
     "EnableMultiLanguage": true,


### PR DESCRIPTION
## Summary
- configure `appsettings.json` with a `${PREVIEW_SECRET}` placeholder
- document that `Security__PreviewSecret` must be set via env var or user secrets

## Testing
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet build` *(fails: A compatible .NET SDK was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850579149f08332bccf2b65fcc22d89