### PR TITLE
Remove preview secret from appsettings

### DIFF
--- a/For Developer/SecurityBook/README.md
+++ b/For Developer/SecurityBook/README.md
@@ -38,10 +38,11 @@ Sistemin təhlükəsizliyini mərkəzləşdirilmiş şəkildə tənzimləmək v�
    secret ilə imzalanmış `token` parametri olmadan `/wireframes/preview/{id}`
    ünvanına giriş verilmir.
 7. **Gizli açarın təyin olunması** – `Security__PreviewSecret` mütləq mühit
-   dəyişəni və ya `dotnet user-secrets` vasitəsilə təyin edilməlidir. Dəyəri
-   `appsettings.json`-da saxlamayın; əks halda proqram başlamayacaq. Boş və ya
-   `${PREVIEW_SECRET}` kimi placeholder dəyərlər qəbul olunmur. Secret-i
-   TPM/HSM əsaslı `TpmHsmSecretStorageService` ilə qorumağı unutmayın.
+   dəyişəni və ya `dotnet user-secrets` vasitəsilə təyin edilməlidir. Default
+   `appsettings.json` bu sahəni boş saxlayır; dəyəri burada qeyd etməyin. Boş və
+   `${PREVIEW_SECRET}` kimi placeholder dəyərlər qəbul olunmur və proqram
+   başlamayacaq. Secret-i TPM/HSM əsaslı `TpmHsmSecretStorageService` ilə
+   qorumağı unutmayın.
 
 ### Default admin hesabının yaradılması
 `DEFAULT_ADMIN_EMAIL` və `DEFAULT_ADMIN_PASSWORD` dəyişənlərini təyin etdikdə, WebAdminPanel ilk başladıqda həmin məlumatlarla admin istifadəçi avtomatik yaradılır.

--- a/README.md
+++ b/README.md
@@ -142,9 +142,10 @@ Slack integration can be enabled by setting
 `Notifications:EnableSlackNotifications` to `true` and specifying the
 `Notifications:SlackWebhookUrl` in `appsettings.json`.
 
-Wireframe previews are protected with a secret token. Set
-`Security__PreviewSecret` via environment variable or the
-`dotnet user-secrets` tool before launch. **Do not place the value in
+Wireframe previews are protected with a secret token. The default
+`appsettings.json` leaves `Security:PreviewSecret` blank, so you must
+provide `Security__PreviewSecret` via an environment variable or the
+`dotnet user-secrets` tool before launch. **Do not store the value in
 `appsettings.json`.** Without this secret the application refuses to
 start.
 

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Program.cs
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Program.cs
@@ -49,7 +49,7 @@ public class Program
                                  previewSecret.Trim().EndsWith("}");
             if (string.IsNullOrWhiteSpace(previewSecret) || hasPlaceholder)
                 throw new InvalidOperationException(
-                    "Security__PreviewSecret environment variable or user secret must be provided for wireframe previews.");
+                    "Security__PreviewSecret must be supplied via environment variable or dotnet user-secrets. Do not store it in appsettings.json.");
             
             // Configure logging
             builder.Host.UseSerilog();

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/appsettings.json
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/appsettings.json
@@ -39,7 +39,7 @@
       "SecurePolicy": "SameAsRequest",
       "SameSite": "Lax"
     },
-    "PreviewSecret": "${PREVIEW_SECRET}"
+    "PreviewSecret": ""
   },
   "Features": {
     "EnableMultiLanguage": true,


### PR DESCRIPTION
## Summary
- remove placeholder PreviewSecret from configuration
- fail fast if environment variable or user secret missing
- document preview secret usage in README and SecurityBook

## Testing
- `dotnet test ASL.LivingGrid.sln --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68506e391ee4833299cc76c685cd0bad