### PR TITLE
Add svg marketplace placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ npm run storybook
 
 Each module can be run independently from its own solution using `dotnet run`.
 
+### Offline Assets
+
+Marketplace previews reference local SVG images stored under
+`WebAdminPanel/ASL.LivingGrid.WebAdminPanel/wwwroot/images/`. These lightweight
+placeholders load even without internet access.
+
 ### 7. Deployment
 
 Publish release binaries with the deploy script:

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/layout_marketplace.json
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/layout_marketplace.json
@@ -4,13 +4,13 @@
     "Name": "Standard",
     "Description": "Default layout with sidebar",
     "DownloadUrl": "https://example.com/layouts/standard.json",
-    "PreviewImage": "https://via.placeholder.com/150x100.png?text=Standard"
+    "PreviewImage": "images/layout_standard.svg"
   },
   {
     "Id": "minimal",
     "Name": "Minimal",
     "Description": "Minimal top-navigation layout",
     "DownloadUrl": "https://example.com/layouts/minimal.json",
-    "PreviewImage": "https://via.placeholder.com/150x100.png?text=Minimal"
+    "PreviewImage": "images/layout_minimal.svg"
   }
 ]

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/plugin_marketplace.json
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/plugin_marketplace.json
@@ -5,6 +5,6 @@
     "Version": "1.0.0",
     "Description": "Example plugin from marketplace",
     "DownloadUrl": "plugins/sample-plugin.json",
-    "PreviewImage": "img/plugin.png"
+    "PreviewImage": "images/plugin.svg"
   }
 ]

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/theme_marketplace.json
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/theme_marketplace.json
@@ -4,13 +4,13 @@
     "Name": "Light",
     "Description": "Default light theme",
     "DownloadUrl": "https://example.com/themes/light.css",
-    "PreviewImage": "https://via.placeholder.com/150x100.png?text=Light"
+    "PreviewImage": "images/theme_light.svg"
   },
   {
     "Id": "dark",
     "Name": "Dark",
     "Description": "Default dark theme",
     "DownloadUrl": "https://example.com/themes/dark.css",
-    "PreviewImage": "https://via.placeholder.com/150x100.png?text=Dark"
+    "PreviewImage": "images/theme_dark.svg"
   }
 ]

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/widget_marketplace.json
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/widget_marketplace.json
@@ -4,13 +4,13 @@
     "Name": "Counter",
     "Description": "Simple counter widget",
     "DownloadUrl": "https://example.com/widgets/counter.json",
-    "PreviewImage": "https://via.placeholder.com/150x100.png?text=Counter"
+    "PreviewImage": "images/widget_counter.svg"
   },
   {
     "Id": "time",
     "Name": "Time",
     "Description": "Current time widget",
     "DownloadUrl": "https://example.com/widgets/time.json",
-    "PreviewImage": "https://via.placeholder.com/150x100.png?text=Time"
+    "PreviewImage": "images/widget_time.svg"
   }
 ]

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/wwwroot/images/layout_minimal.svg
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/wwwroot/images/layout_minimal.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100" fill="#ddd" />
+  <text x="50%" y="50%" font-size="12" text-anchor="middle" fill="#333" dy=".3em">Layout Minimal</text>
+</svg>

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/wwwroot/images/layout_standard.svg
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/wwwroot/images/layout_standard.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100" fill="#ddd" />
+  <text x="50%" y="50%" font-size="12" text-anchor="middle" fill="#333" dy=".3em">Layout Standard</text>
+</svg>

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/wwwroot/images/plugin.svg
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/wwwroot/images/plugin.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100" fill="#ddd" />
+  <text x="50%" y="50%" font-size="12" text-anchor="middle" fill="#333" dy=".3em">Plugin</text>
+</svg>

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/wwwroot/images/theme_dark.svg
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/wwwroot/images/theme_dark.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100" fill="#ddd" />
+  <text x="50%" y="50%" font-size="12" text-anchor="middle" fill="#333" dy=".3em">Theme Dark</text>
+</svg>

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/wwwroot/images/theme_light.svg
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/wwwroot/images/theme_light.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100" fill="#ddd" />
+  <text x="50%" y="50%" font-size="12" text-anchor="middle" fill="#333" dy=".3em">Theme Light</text>
+</svg>

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/wwwroot/images/widget_counter.svg
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/wwwroot/images/widget_counter.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100" fill="#ddd" />
+  <text x="50%" y="50%" font-size="12" text-anchor="middle" fill="#333" dy=".3em">Widget Counter</text>
+</svg>

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/wwwroot/images/widget_time.svg
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/wwwroot/images/widget_time.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100" fill="#ddd" />
+  <text x="50%" y="50%" font-size="12" text-anchor="middle" fill="#333" dy=".3em">Widget Time</text>
+</svg>


### PR DESCRIPTION
## Summary
- replace PNG placeholder images with lightweight SVG
- update marketplace JSON to reference new SVG paths
- document offline asset location in README

## Testing
- `dotnet build ASL.LivingGrid.sln` *(fails: package downgrade)*
- `dotnet test ASL.LivingGrid.sln --no-build` *(fails: invalid arguments)*

------
https://chatgpt.com/codex/tasks/task_e_68506c3e5c3c8332bbf621939cd44027