### PR TITLE
Implement CPU sampling for process monitor

### DIFF
--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel.Tests/Services/ProcessMonitorServiceTests.cs
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel.Tests/Services/ProcessMonitorServiceTests.cs
@@ -1,0 +1,23 @@
+using System.Linq;
+using System.Threading.Tasks;
+using ASL.LivingGrid.WebAdminPanel.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace ASL.LivingGrid.WebAdminPanel.Tests.Services;
+
+public class ProcessMonitorServiceTests
+{
+    [Fact]
+    public async Task ListAsync_ComputesCpuUsage()
+    {
+        var service = new ProcessMonitorService(new NullLogger<ProcessMonitorService>());
+        // first call initializes samples
+        await service.ListAsync();
+        await Task.Delay(100);
+        var second = await service.ListAsync();
+
+        Assert.NotEmpty(second);
+        Assert.All(second, p => Assert.True(p.CpuUsage >= 0));
+    }
+}

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Services/IProcessMonitorService.cs
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Services/IProcessMonitorService.cs
@@ -1,6 +1,8 @@
+using System;
+
 namespace ASL.LivingGrid.WebAdminPanel.Services;
 
-public record ProcessInfo(int Id, string Name, double CpuUsage, double MemoryMb);
+public record ProcessInfo(int Id, string Name, double CpuUsage, double MemoryMb, DateTime StartTime);
 
 public interface IProcessMonitorService
 {

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Services/ProcessMonitorService.cs
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/Services/ProcessMonitorService.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 
@@ -6,6 +8,8 @@ namespace ASL.LivingGrid.WebAdminPanel.Services;
 public class ProcessMonitorService : IProcessMonitorService
 {
     private readonly ILogger<ProcessMonitorService> _logger;
+    private readonly Dictionary<int, (TimeSpan Cpu, DateTime Timestamp)> _samples = new();
+    private readonly int _processorCount = Environment.ProcessorCount;
 
     public ProcessMonitorService(ILogger<ProcessMonitorService> logger)
     {
@@ -14,13 +18,52 @@ public class ProcessMonitorService : IProcessMonitorService
 
     public Task<IEnumerable<ProcessInfo>> ListAsync()
     {
-        var list = Process.GetProcesses().Take(20).Select(p =>
+        var processes = Process.GetProcesses().Take(20);
+        var now = DateTime.UtcNow;
+        var list = new List<ProcessInfo>();
+
+        foreach (var p in processes)
         {
-            double memory = p.WorkingSet64 / 1024d / 1024d;
-            double cpu = 0; // placeholder
-            return new ProcessInfo(p.Id, p.ProcessName, cpu, memory);
-        });
-        return Task.FromResult(list);
+            double memory = 0;
+            double cpu = 0;
+            DateTime startTime = DateTime.MinValue;
+            try
+            {
+                memory = p.WorkingSet64 / 1024d / 1024d;
+                startTime = p.StartTime;
+                var totalCpu = p.TotalProcessorTime;
+
+                if (_samples.TryGetValue(p.Id, out var sample))
+                {
+                    var deltaCpu = totalCpu - sample.Cpu;
+                    var deltaTime = now - sample.Timestamp;
+                    if (deltaTime.TotalMilliseconds > 0)
+                    {
+                        cpu = deltaCpu.TotalMilliseconds / (deltaTime.TotalMilliseconds * _processorCount) * 100;
+                    }
+                    _samples[p.Id] = (totalCpu, now);
+                }
+                else
+                {
+                    _samples[p.Id] = (totalCpu, now);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Failed to read process info {Id}", p.Id);
+            }
+
+            list.Add(new ProcessInfo(p.Id, p.ProcessName, cpu, memory, startTime));
+        }
+
+        var activeIds = processes.Select(pr => pr.Id).ToHashSet();
+        var remove = _samples.Keys.Where(id => !activeIds.Contains(id)).ToList();
+        foreach (var id in remove)
+        {
+            _samples.Remove(id);
+        }
+
+        return Task.FromResult<IEnumerable<ProcessInfo>>(list);
     }
 
     public Task<bool> KillAsync(int id)


### PR DESCRIPTION
## Summary
- compute CPU usage by sampling `TotalProcessorTime`
- track start time in `ProcessInfo`
- add a unit test for the process monitor service

## Testing
- `dotnet test WebAdminPanel/ASL.LivingGrid.WebAdminPanel.Tests/ASL.LivingGrid.WebAdminPanel.Tests.csproj -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850703ad588833281377a8e503b3a2c