### PR TITLE
Remove example.com placeholders

### DIFF
--- a/Docs/samples/README.md
+++ b/Docs/samples/README.md
@@ -1,0 +1,19 @@
+# Sample Packages and Configurations
+
+This folder contains local sample files used by the Marketplace features and configuration examples.
+
+- `widgets/` – sample widget JSON files
+- `layouts/` – sample layout definitions
+- `themes/` – sample theme stylesheets
+- `cloud/` – sample cloud function info
+
+Reference these files in your configuration or replace them with URLs to your own packages when deploying to production.
+
+## Sync Nodes
+
+The example `sync_nodes.json` file points here so you can document your own node URLs. Update it with reachable addresses in production.
+
+## Failover
+
+Use this section to list standby or failover nodes referenced by
+`disaster_recovery.json`. Replace these placeholders with your actual addresses.

--- a/Docs/samples/cloud/README.md
+++ b/Docs/samples/cloud/README.md
@@ -1,0 +1,3 @@
+# Cloud Function Samples
+
+Use this folder to store sample function endpoints for testing. Update `cloudFunctions.json` to point to real endpoints in production.

--- a/Docs/samples/layouts/minimal.json
+++ b/Docs/samples/layouts/minimal.json
@@ -1,0 +1,6 @@
+{
+  "Id": "minimal",
+  "Name": "Minimal",
+  "Description": "Minimal top-navigation layout",
+  "Regions": ["Header", "Content"]
+}

--- a/Docs/samples/layouts/standard.json
+++ b/Docs/samples/layouts/standard.json
@@ -1,0 +1,6 @@
+{
+  "Id": "standard",
+  "Name": "Standard",
+  "Description": "Default layout with sidebar",
+  "Regions": ["Sidebar", "Main"]
+}

--- a/Docs/samples/themes/dark.css
+++ b/Docs/samples/themes/dark.css
@@ -1,0 +1,9 @@
+:root {
+    --bg-color: #212529;
+    --text-color: #f8f9fa;
+    --primary-color: #0d6efd;
+}
+body[data-theme='dark'] {
+    background-color: var(--bg-color);
+    color: var(--text-color);
+}

--- a/Docs/samples/themes/light.css
+++ b/Docs/samples/themes/light.css
@@ -1,0 +1,9 @@
+:root {
+    --bg-color: #ffffff;
+    --text-color: #212529;
+    --primary-color: #0d6efd;
+}
+body[data-theme='light'] {
+    background-color: var(--bg-color);
+    color: var(--text-color);
+}

--- a/Docs/samples/widgets/counter.json
+++ b/Docs/samples/widgets/counter.json
@@ -1,0 +1,6 @@
+{
+  "Id": "counter",
+  "Name": "Counter",
+  "Description": "Simple counter widget",
+  "Component": "counter"
+}

--- a/Docs/samples/widgets/marketplace.json
+++ b/Docs/samples/widgets/marketplace.json
@@ -1,0 +1,16 @@
+[
+  {
+    "Id": "counter",
+    "Name": "Counter",
+    "Description": "Simple counter widget",
+    "DownloadUrl": "counter.json",
+    "PreviewImage": "widget_counter.svg"
+  },
+  {
+    "Id": "time",
+    "Name": "Time",
+    "Description": "Current time widget",
+    "DownloadUrl": "time.json",
+    "PreviewImage": "widget_time.svg"
+  }
+]

--- a/Docs/samples/widgets/time.json
+++ b/Docs/samples/widgets/time.json
@@ -1,0 +1,6 @@
+{
+  "Id": "time",
+  "Name": "Time",
+  "Description": "Current time widget",
+  "Component": "time"
+}

--- a/For Developer/DeploymentBook/README.md
+++ b/For Developer/DeploymentBook/README.md
@@ -60,7 +60,7 @@ Komanda sətrindən `--standalone` və ya `--hosted` parametrini əlavə etməkl
 ### Serverless Mühit üçün Cloud Functions
 `CloudFunctionService` serverless ssenariləri üçün `cloudFunctions.json` faylından URL-ləri oxuyur. Konfiqurasiya etmək üçün:
 1. WebAdminPanel kök qovluğunda `cloudFunctions.json` yaradın.
-2. Faylda hər funksiyanın adını və HTTP endpoint ünvanını `{"FunctionName": "https://example.com/api"}` formatında göstərin.
+2. Faylda hər funksiyanın adını və HTTP endpoint ünvanını `{"FunctionName": "https://your-function-url"}` formatında göstərin. Nümunə üçün `Docs/samples/cloud/README.md` qovluğuna baxın.
 3. Müxtəlif mühitlər (dev/stage/prod) üçün ayrıca fayl saxlamaq və yerləşdirmə zamanı uyğun nüsxəni kopyalamaq tövsiyə olunur.
 4. Tətbiq işə düşərkən `CloudFunctionService` bu faylı oxuyur və `InvokeAsync` metodu ilə URL-ə JSON sorğu göndərir.
 5. Dəyişiklik etdikdən sonra tətbiqi yenidən başladaraq funksiyaların yenilənməsinə əmin olun.

--- a/README.md
+++ b/README.md
@@ -113,6 +113,14 @@ Marketplace previews reference local SVG images stored under
 `WebAdminPanel/ASL.LivingGrid.WebAdminPanel/wwwroot/images/`. These lightweight
 placeholders load even without internet access.
 
+### Marketplace Samples
+
+Theme, widget, layout and plugin marketplaces read from JSON manifests. Sample
+manifests in this repo point to files under `Docs/samples/`. To host real
+packages, publish your own manifest on an HTTP server and set the appropriate
+`*Marketplace:Source` configuration key to its URL. The WebAdminPanel import
+buttons also accept these local sample files for offline development.
+
 ### 7. Deployment
 
 Publish release binaries with the deploy script:

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel.Tests/Services/ThemeMarketplaceServiceTests.cs
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel.Tests/Services/ThemeMarketplaceServiceTests.cs
@@ -18,7 +18,7 @@ public class ThemeMarketplaceServiceTests
     {
         using var tempDir = new TemporaryDirectory();
         var jsonFile = Path.Combine(tempDir.Path, "theme_marketplace.json");
-        var json = "[{"Id":"dark","Name":"Dark","Description":"Desc","DownloadUrl":"http://example.com/dark.css","PreviewImage":"img"}]";
+        var json = "[{"Id":"dark","Name":"Dark","Description":"Desc","DownloadUrl":"../../Docs/samples/themes/dark.css","PreviewImage":"img"}]";
         await File.WriteAllTextAsync(jsonFile, json);
 
         var envMock = new Mock<IWebHostEnvironment>();
@@ -43,7 +43,7 @@ public class ThemeMarketplaceServiceTests
         using var tempDir = new TemporaryDirectory();
         Directory.CreateDirectory(Path.Combine(tempDir.Path, "css", "themes"));
         var jsonFile = Path.Combine(tempDir.Path, "theme_marketplace.json");
-        var json = "[{\"Id\":\"dark\",\"Name\":\"Dark\",\"Description\":\"Desc\",\"DownloadUrl\":\"http://example.com/dark.css\",\"PreviewImage\":\"img\"}]";
+        var json = "[{\"Id\":\"dark\",\"Name\":\"Dark\",\"Description\":\"Desc\",\"DownloadUrl\":\"../../Docs/samples/themes/dark.css\",\"PreviewImage\":\"img\"}]";
         await File.WriteAllTextAsync(jsonFile, json);
 
         var handlerMock = new Mock<HttpMessageHandler>();

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel.Tests/Services/WidgetMarketplaceServiceTests.cs
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel.Tests/Services/WidgetMarketplaceServiceTests.cs
@@ -19,7 +19,7 @@ public class WidgetMarketplaceServiceTests
     {
         using var tempDir = new TemporaryDirectory();
         var jsonFile = Path.Combine(tempDir.Path, "widget_marketplace.json");
-        var json = "[{\"Id\":\"w1\",\"Name\":\"Widget\",\"Description\":\"Desc\",\"DownloadUrl\":\"http://example.com/widget.json\",\"PreviewImage\":\"img\"}]";
+        var json = "[{\"Id\":\"w1\",\"Name\":\"Widget\",\"Description\":\"Desc\",\"DownloadUrl\":\"../../Docs/samples/widgets/counter.json\",\"PreviewImage\":\"img\"}]";
         await File.WriteAllTextAsync(jsonFile, json);
 
         var envMock = new Mock<IWebHostEnvironment>();
@@ -43,7 +43,7 @@ public class WidgetMarketplaceServiceTests
             .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
             .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
             {
-                Content = new StringContent("[{\\"Id\\":\\"w1\\",\\"Name\\":\\"Widget\\",\\"Description\\":\\"Desc\\",\\"DownloadUrl\\":\\"http://example.com/widget.json\\",\\"PreviewImage\\":\\"img\\"}]")
+                Content = new StringContent("[{\\"Id\\":\\"w1\\",\\"Name\\":\\"Widget\\",\\"Description\\":\\"Desc\\",\\"DownloadUrl\\":\\"../../Docs/samples/widgets/counter.json\\",\\"PreviewImage\\":\\"img\\"}]")
             });
         var httpClient = new HttpClient(handlerMock.Object);
         var factoryMock = new Mock<IHttpClientFactory>();
@@ -56,7 +56,7 @@ public class WidgetMarketplaceServiceTests
         var loggerMock = new Mock<ILogger<WidgetMarketplaceService>>();
         var configuration = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
         {
-            ["WidgetMarketplace:Source"] = "http://example.com/marketplace.json"
+            ["WidgetMarketplace:Source"] = "../../Docs/samples/widgets/marketplace.json"
         }).Build();
         var service = new WidgetMarketplaceService(envMock.Object, factoryMock.Object, loggerMock.Object, configuration);
 
@@ -71,7 +71,7 @@ public class WidgetMarketplaceServiceTests
         using var tempDir = new TemporaryDirectory();
         Directory.CreateDirectory(Path.Combine(tempDir.Path, "www", "widgets"));
         var jsonFile = Path.Combine(tempDir.Path, "widget_marketplace.json");
-        var marketplaceJson = "[{\"Id\":\"w1\",\"Name\":\"Widget\",\"Description\":\"Desc\",\"DownloadUrl\":\"http://example.com/widget.json\",\"PreviewImage\":\"img\"}]";
+        var marketplaceJson = "[{\"Id\":\"w1\",\"Name\":\"Widget\",\"Description\":\"Desc\",\"DownloadUrl\":\"../../Docs/samples/widgets/counter.json\",\"PreviewImage\":\"img\"}]";
         await File.WriteAllTextAsync(jsonFile, marketplaceJson);
 
         var widgetJson = "{\"Id\":\"w1\"}";

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/cloudFunctions.json
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/cloudFunctions.json
@@ -1,3 +1,3 @@
 {
-  "SampleFunction": "https://example.com/api/sample"
+  "SampleFunction": "../Docs/samples/cloud/README.md"
 }

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/disaster_recovery.json
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/disaster_recovery.json
@@ -1,7 +1,7 @@
 {
   "BackupPath": "backups",
   "FailoverNodes": [
-    "https://failover1.example.com",
-    "https://failover2.example.com"
+    "../Docs/samples/README.md#failover",
+    "../Docs/samples/README.md#failover"
   ]
 }

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/layout_marketplace.json
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/layout_marketplace.json
@@ -3,14 +3,14 @@
     "Id": "standard",
     "Name": "Standard",
     "Description": "Default layout with sidebar",
-    "DownloadUrl": "https://example.com/layouts/standard.json",
+    "DownloadUrl": "../../Docs/samples/layouts/standard.json",
     "PreviewImage": "images/layout_standard.svg"
   },
   {
     "Id": "minimal",
     "Name": "Minimal",
     "Description": "Minimal top-navigation layout",
-    "DownloadUrl": "https://example.com/layouts/minimal.json",
+    "DownloadUrl": "../../Docs/samples/layouts/minimal.json",
     "PreviewImage": "images/layout_minimal.svg"
   }
 ]

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/sync_nodes.json
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/sync_nodes.json
@@ -1,4 +1,4 @@
 [
-  "https://node1.example.com",
-  "https://node2.example.com"
+  "../Docs/samples/README.md#sync-nodes",
+  "../Docs/samples/README.md#sync-nodes"
 ]

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/theme_marketplace.json
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/theme_marketplace.json
@@ -3,14 +3,14 @@
     "Id": "light",
     "Name": "Light",
     "Description": "Default light theme",
-    "DownloadUrl": "https://example.com/themes/light.css",
+    "DownloadUrl": "../../Docs/samples/themes/light.css",
     "PreviewImage": "images/theme_light.svg"
   },
   {
     "Id": "dark",
     "Name": "Dark",
     "Description": "Default dark theme",
-    "DownloadUrl": "https://example.com/themes/dark.css",
+    "DownloadUrl": "../../Docs/samples/themes/dark.css",
     "PreviewImage": "images/theme_dark.svg"
   }
 ]

--- a/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/widget_marketplace.json
+++ b/WebAdminPanel/ASL.LivingGrid.WebAdminPanel/widget_marketplace.json
@@ -3,14 +3,14 @@
     "Id": "counter",
     "Name": "Counter",
     "Description": "Simple counter widget",
-    "DownloadUrl": "https://example.com/widgets/counter.json",
+    "DownloadUrl": "../../Docs/samples/widgets/counter.json",
     "PreviewImage": "images/widget_counter.svg"
   },
   {
     "Id": "time",
     "Name": "Time",
     "Description": "Current time widget",
-    "DownloadUrl": "https://example.com/widgets/time.json",
+    "DownloadUrl": "../../Docs/samples/widgets/time.json",
     "PreviewImage": "images/widget_time.svg"
   }
 ]


### PR DESCRIPTION
## Summary
- point marketplace manifests to local sample files
- add Marketplace docs and samples
- note sample cloud function config
- update tests for local file paths

## Testing
- `dotnet test` *(fails: command not found)*
- `npm run build-storybook` *(fails: storybook not found)*

------
https://chatgpt.com/codex/tasks/task_e_685071b82af083329b980f6ed5618c1a